### PR TITLE
Runtime fixes for dragen workflow

### DIFF
--- a/rmd_files/RNAseq_report.R
+++ b/rmd_files/RNAseq_report.R
@@ -19,6 +19,7 @@
 #   sample_name:  The name of the sample to be analysed and reported
 #   bcbio_rnaseq: Location of the results folder from bcbio RNA-seq pipeline
 #   dragen_rnaseq:Location of the results folder from dragen RNA-seq pipeline
+#   arriba_rnaseq:Location of the arriba folder from the dragen rnaseq pipeline
 #   dataset:      Dataset to be used as external reference cohort (default is "PANCAN")
 #   report_dir:   Desired location for the report
 #   ref_data_dir: Location of the reference and annotation files
@@ -80,6 +81,8 @@ option_list = list(
               help="Location of the results folder from bcbio RNA-seq pipeline"),
   make_option("--dragen_rnaseq", action="store", default=NULL, type='character',
               help="Location of the results folder from Dragen RNA-seq pipeline"),
+  make_option("--arriba_rnaseq", action="store", default=NULL, type='character',
+              help="Location of the results folder from Arriba RNA-seq pipeline"),
   make_option("--report_dir", action="store", default=NA, type='character',
               help="Desired location for the report"),
   make_option("--ref_data_dir", action="store", default="../data", type='character',
@@ -273,6 +276,7 @@ param_list <- list(sample_name = opt$sample_name,
                dataset = toupper(opt$dataset),
                bcbio_rnaseq = opt$bcbio_rnaseq,
                dragen_rnaseq = opt$dragen_rnaseq,
+               arriba_rnaseq = opt$arriba_rnaseq,
                report_dir = opt$report_dir,
                ref_data_dir = opt$ref_data_dir,
                transform = opt$transform,

--- a/rmd_files/RNAseq_report.Rmd
+++ b/rmd_files/RNAseq_report.Rmd
@@ -18,6 +18,7 @@ params:
   dataset: 'TEST'
   bcbio_rnaseq: '../data/test_data/final/test_sample_WTS'
   dragen_rnaseq: NULL
+  arriba_rnaseq: NULL
   report_dir: '../data/test_data/final/test_sample_WTS/RNAsum'
   ref_data_dir: '../data'
   transform: 'CPM'
@@ -1939,8 +1940,13 @@ if ( params$immunogram ) {
 ##### Read in gene fusion data for investigate sample
 ##### Read in arriba and pizzly fusion calls
 ##### Check if arriba output file exists
-arriba_file <- paste(dataDir, "arriba", "fusions.tsv", sep = "/")
-arriba_pdf <- paste(dataDir, "arriba", "fusions.pdf", sep = "/")
+if ( !is.null(params$arriba_rnaseq) ) {
+    arribaDir <- params$arriba_rnaseq
+} else {
+    arribaDir <- paste(dataDir, "arriba", sep="/")
+}
+arriba_file <- paste(arribaDir, "fusions.tsv", sep = "/")
+arriba_pdf <- paste(arribaDir, "fusions.pdf", sep = "/")
 runArribaChunk <- FALSE
 runFusionChunk <- FALSE
 

--- a/rmd_files/RNAseq_report.Rmd
+++ b/rmd_files/RNAseq_report.Rmd
@@ -1899,10 +1899,10 @@ if ( !is.null(params$bcbio_rnaseq) ) {
 } else if ( !is.null(params$dragen_rnaseq) ) {
   
   ##### Get patient data dir and sample file name
-  dataDir <- paste(params$dragen_rnaseq, "dragen", sep = "/")
+  dataDir <- params$dragen_rnaseq
   
   ##### Look at countsFromAbundance parameter to change the method to generate the counts
-  txi.salmon <- tximport(paste0(dataDir, "/", list.files(dataDir, pattern="\\.sf$")), type = "salmon", tx2gene = tx2ensembl)
+  txi.salmon <- tximport(paste0(dataDir, "/", list.files(dataDir, pattern=".quant.sf$")), type = "salmon", tx2gene = tx2ensembl)
   
   ##### Extract salmon counts to prepare dataframe
   counts <- as.data.frame(txi.salmon$counts) %>%


### PR DESCRIPTION
## TODOs

- [x] Push container with changes to tag `0.4.2-dev`
- [x] Restructure reference data, see below
- [x] Test on ICA 

## Updates

* Remove 'dragen' nested directory
  * User must specify 
* Select quant.sf transcript abundance file only

## Justifications

### Transcriptome directory changes

RNASum workflow succeeded with `wfr.6ac9fd6da917415f95c6037d45c6c79c` where the inputs were:

```json
{
  "dataset": "PAAD",
  "dragen_transcriptome_directory": {
    "class": "Directory",
    "location": "gds://stratus-sehrish2/data/wts/rnasum/final/SBJ00238_MDX190231_L1901028"
  },
  "ref_data_directory": {
    "class": "Directory",
    "location": "gds://stratus-sehrish2/data/wts/rnasum/ref-data"
  },
  "report_directory": "SBJ00238",
  "sample_name": "SBJ00238_MDX190231_L1901028",
  "save_tables": false,
  "umccrise_directory": {
    "class": "Directory",
    "location": "gds://stratus-sehrish2/data/wts/rnasum/umccrised/SBJ00238__SBJ00238_MDX190230_L1901041"
  }
}
```

```
gds://stratus-sehrish2/data/wts/rnasum/final/SBJ00238_MDX190231_L1901028
```

Is quite a bit different to a regular transcriptome output directory.

```
$ gds-ls gds://stratus-sehrish2/data/wts/rnasum/final/SBJ00238_MDX190231_L1901028/
gds://stratus-sehrish2/data/wts/rnasum/final/SBJ00238_MDX190231_L1901028/dragen/
gds://stratus-sehrish2/data/wts/rnasum/final/SBJ00238_MDX190231_L1901028/kallisto/
```

Instead. with a regular transcriptome run, there is no `dragen` subdirectory, therefore we expect the user to instead set `--dragen_rnaseq` to be the directory transcriptome output directory, such as `gds://development/analysis_data/SBJ00915/wts_tumor_only/20220312ed9316ac/L2100739_dragen`


### .sf pattern search to .quant.sf pattern search

In the test directory used for  `wfr.6ac9fd6da917415f95c6037d45c6c79c` the dragen directory only comprised of `L1901028.quant.sf` however a regular transcriptome output directory will also have `L1901028.quant.genes.sf`.  

The `*.quant.genes.sf` files contain gene level counts as opposed to transcript level counts and therefore should not be selected when listing files ending in `.sf`.  Therefore the pattern search was made more specific by selecting only files ending in `.quant.sf`


## Other issues

Compared to `wfr.6ac9fd6da917415f95c6037d45c6c79c` where the ref-data was set at `gds://stratus-sehrish2/data/wts/rnasum/ref-data/` where the directory structure is slightly different to `gds://development/reference-data/rnasum/ref_data/` 

```
$ gds-ls gds://development/reference-data/rnasum/
gds://development/reference-data/rnasum/cancer_biomarkers_database/
gds://development/reference-data/rnasum/CIViC/
gds://development/reference-data/rnasum/genes/
gds://development/reference-data/rnasum/ref_data/
gds://development/reference-data/rnasum/test_data/
$ gds-ls gds://stratus-sehrish2/data/wts/rnasum/ref-data/
gds://stratus-sehrish2/data/wts/rnasum/ref-data/cancer_biomarkers_database/
gds://stratus-sehrish2/data/wts/rnasum/ref-data/CIViC/
gds://stratus-sehrish2/data/wts/rnasum/ref-data/FusionGDB/
gds://stratus-sehrish2/data/wts/rnasum/ref-data/genes/
gds://stratus-sehrish2/data/wts/rnasum/ref-data/OncoKB/
gds://stratus-sehrish2/data/wts/rnasum/ref-data/ref_data/
gds://stratus-sehrish2/data/wts/rnasum/ref-data/test_data/
```

```
$ gds-ls gds://development/reference-data/rnasum/CIViC/
gds://development/reference-data/rnasum/CIViC/01-Oct-2018-ClinicalEvidenceSummaries.tsv
gds://development/reference-data/rnasum/CIViC/01-Oct-2018-GeneSummaries.tsv
gds://development/reference-data/rnasum/CIViC/01-Oct-2018-VariantGroupSummaries.tsv
gds://development/reference-data/rnasum/CIViC/01-Oct-2018-VariantSummaries.tsv
gds://development/reference-data/rnasum/CIViC/FusionGDB/
gds://development/reference-data/rnasum/CIViC/OnkoKB/
```


It appears that `FusionGDB` and `OncoKB` have been placed inside `gds://development/reference-data/rnasum/CIViC/` 

And `OncoKB` has been moved to `OnkoKB`. I believe these are mistakes since the report RMD hard codes these values to their original relative paths to the reference directory.  Just would like someone else to approve this before I move this data.