### PR TITLE
Major report cleanup with `styler::tidyverse_style()`

### DIFF
--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -89,9 +89,9 @@ Transcriptome summary for patient sample **`r paste0(params$sample_name, params$
 # 14. ref_dataset.list[[dataset]][["expr_mut_cn_data"]] = combined expression, mutation and copy-number data limited to cancer genes that meet user-deinfed CN values threshold
 
 ##### Genes of interest are stored in "ref_genes.list" list variable with elements holding the following gene sets:
-# 1. ref_genes.list[["genes_cancer"]] = list of cancer genes derived from UMCCR Cancer Gene list (https://github.com/vladsaveliev/NGS_Utils/blob/master/ngs_utils/reference_data/key_genes/umccr_cancer_genes.2019-03-20.tsv) and OncoKB portal (http://oncokb.org/#/cancerGenes) 
+# 1. ref_genes.list[["genes_cancer"]] = list of cancer genes derived from UMCCR Cancer Gene list (https://github.com/vladsaveliev/NGS_Utils/blob/master/ngs_utils/reference_data/key_genes/umccr_cancer_genes.2019-03-20.tsv) and OncoKB portal (http://oncokb.org/#/cancerGenes)
 # 2. ref_genes.list[["genes_oncokb"]] = list of cancer genes derived from OncoKB portal (http://oncokb.org/#/cancerGenes) alone (although genes present on the UMCCR panel are also flagged)
-# 3. ref_genes.list[["genes_immune"]] = list of immune reponse markers provided in the "An Immunogram for the Cancer-Immunity Cycle" paper by Karasaki at al (2017) (https://www.ncbi.nlm.nih.gov/pubmed/28088513) and OmniSeq report (https://www.omniseq.com/) 
+# 3. ref_genes.list[["genes_immune"]] = list of immune reponse markers provided in the "An Immunogram for the Cancer-Immunity Cycle" paper by Karasaki at al (2017) (https://www.ncbi.nlm.nih.gov/pubmed/28088513) and OmniSeq report (https://www.omniseq.com/)
 # 4. ref_genes.list[["genes_hrd"]] = list of hrd (homologous recombination deficiency) genes
 # 5. ref_genes.list[["pcgr"]] = list and PCGR annotation of mutated genes in given patient based on PCGR report
 # 6. ref_genes.list[["purple"]] = list and PURPLE annotation of copy-number (CN) altered genes in given patient based on PURPLE results
@@ -102,8 +102,8 @@ Transcriptome summary for patient sample **`r paste0(params$sample_name, params$
 ```
 
 ```{r code_display, echo = FALSE}
-##### Include or exclude the "Code" button allowing to "show"/"hide" code chunks from the report 
-if ( params$hide_code_btn ) {
+##### Include or exclude the "Code" button allowing to "show"/"hide" code chunks from the report
+if (params$hide_code_btn) {
   writeLines(".btn { display: none ;", con = "RNAseq_report.css")
 } else {
   writeLines(" ", con = "RNAseq_report.css")
@@ -115,7 +115,6 @@ NOW <- Sys.time()
 
 ##### Time chunks during knitting
 knitr::knit_hooks$set(timeit = function(before) {
-  
   if (before) {
     print(paste("Start:", Sys.time()))
     NOW <<- Sys.time()
@@ -131,8 +130,7 @@ knitr::opts_chunk$set(timeit = TRUE)
 ```{r define_functions, comment=NA, message=FALSE, warning=FALSE}
 ##### Define functions
 ##### Create 'not in' operator
-"%!in%" <- function(x,table) match(x,table, nomatch = 0) == 0
-
+"%!in%" <- function(x, table) match(x, table, nomatch = 0) == 0
 ```
 
 ```{r plot_thumbnail, comment=NA, message=FALSE, warning=FALSE}
@@ -169,13 +167,13 @@ suppressMessages(library(htmltools))
 suppressMessages(library(htmlwidgets))
 suppressMessages(library(devtools))
 suppressMessages(library(lares))
-suppressMessages(library(package=paste0("EnsDb.Hsapiens.v", params$ensembl_version), character.only = TRUE))
-suppressMessages(library(package=paste0("BSgenome.Hsapiens.UCSC.hg", params$ucsc_genome_assembly), character.only = TRUE))
+suppressMessages(library(package = paste0("EnsDb.Hsapiens.v", params$ensembl_version), character.only = TRUE))
+suppressMessages(library(package = paste0("BSgenome.Hsapiens.UCSC.hg", params$ucsc_genome_assembly), character.only = TRUE))
 ```
 
 ```{r prepare_parameters, message=FALSE, warning=FALSE}
 ##### Define Z-transformation direction
-if (tolower(params$scaling) == "gene-wise"){
+if (tolower(params$scaling) == "gene-wise") {
   scaling <- "gene-wise"
 } else {
   scaling <- "group-wise"
@@ -185,15 +183,15 @@ if (tolower(params$scaling) == "gene-wise"){
 ```{r tx2ensembl, comment = NA, message=FALSE, warning=FALSE}
 ##### Annotate transcripts with gene IDs
 edb <- eval(parse(text = paste0("EnsDb.Hsapiens.v", params$ensembl_version)))
-  
+
 ##### Get keytypes for gene SYMBOL
-keys <- keys(edb, keytype="GENEID")
-  
+keys <- keys(edb, keytype = "GENEID")
+
 ##### Get genes genomic coordiantes
-tx2ensembl <- ensembldb::select(edb, keys=keys, columns=c("TXID", "GENEID"), keytype="GENEID")
+tx2ensembl <- ensembldb::select(edb, keys = keys, columns = c("TXID", "GENEID"), keytype = "GENEID")
 names(tx2ensembl) <- gsub("TXID", "tx_name", names(tx2ensembl))
 names(tx2ensembl) <- gsub("GENEID", "gene_id", names(tx2ensembl))
-  
+
 ##### Clean the space
 rm(edb, keys)
 ```
@@ -203,8 +201,9 @@ rm(edb, keys)
 ##### Define the reference datasets based on user-defined input
 dataset <- toupper(params$dataset)
 
-ref_dataset <- list( "ext_ref" = c(paste0(params$ref_data_dir, "/ref_data/TCGA_", strsplit(dataset, split='-', fixed=TRUE)[[1]][1], "_Counts.exp.gz"), paste0(params$ref_data_dir, "/ref_data/TCGA_", dataset, "_Target.txt"), paste0(strsplit(dataset, split='-', fixed=TRUE)[[1]][1], " (TCGA)")),
-                     "int_ref" = c(paste0(params$ref_data_dir, "/ref_data/UMCCR_PDAC_Counts.exp.gz"), paste0(params$ref_data_dir, "/ref_data/UMCCR_PDAC_Target.txt"), "PAAD (UMCCR)")
+ref_dataset <- list(
+  "ext_ref" = c(paste0(params$ref_data_dir, "/ref_data/TCGA_", strsplit(dataset, split = "-", fixed = TRUE)[[1]][1], "_Counts.exp.gz"), paste0(params$ref_data_dir, "/ref_data/TCGA_", dataset, "_Target.txt"), paste0(strsplit(dataset, split = "-", fixed = TRUE)[[1]][1], " (TCGA)")),
+  "int_ref" = c(paste0(params$ref_data_dir, "/ref_data/UMCCR_PDAC_Counts.exp.gz"), paste0(params$ref_data_dir, "/ref_data/UMCCR_PDAC_Target.txt"), "PAAD (UMCCR)")
 )
 
 ##### Create a list with reference datasets
@@ -222,33 +221,30 @@ caner_genes_annot.list <- vector("list", length(caner_genes_annot))
 names(caner_genes_annot.list) <- caner_genes_annot
 
 ##### Get the subject ID
-if ( !is.na(params$subject_id) ) {
+if (!is.na(params$subject_id)) {
   subjectID <- params$subject_id
 } else {
   subjectID <- ""
 }
 
-if ( !is.null(params$bcbio_rnaseq) ) {
-  
+if (!is.null(params$bcbio_rnaseq)) {
   ##### Get patient data dir and sample file name
   dataDir <- params$bcbio_rnaseq
-  
+
   ##### Look at countsFromAbundance parameter to change the method to generate the counts
   txi.kallisto <- tximport(paste0(dataDir, "/kallisto/abundance.tsv"), type = "kallisto", tx2gene = tx2ensembl)
-  
+
   ##### Extract kallisto counts to prepare dataframe
   counts <- as.data.frame(txi.kallisto$counts) %>%
     tibble::rownames_to_column() %>%
     dplyr::rename(count = V1)
-  
-} else if ( !is.null(params$dragen_rnaseq) ) {
-  
+} else if (!is.null(params$dragen_rnaseq)) {
   ##### Get patient data dir and sample file name
   dataDir <- params$dragen_rnaseq
-  
+
   ##### Look at countsFromAbundance parameter to change the method to generate the counts
-  txi.salmon <- tximport(paste0(dataDir, "/", list.files(dataDir, pattern=".quant.sf$")), type = "salmon", tx2gene = tx2ensembl)
-  
+  txi.salmon <- tximport(paste0(dataDir, "/", list.files(dataDir, pattern = ".quant.sf$")), type = "salmon", tx2gene = tx2ensembl)
+
   ##### Extract salmon counts to prepare dataframe
   counts <- as.data.frame(txi.salmon$counts) %>%
     tibble::rownames_to_column() %>%
@@ -258,95 +254,91 @@ if ( !is.null(params$bcbio_rnaseq) ) {
 ##### Create directory for results
 results_dir <- paste0(params$report_dir, "/", params$sample_name, params$dataset_name_incl, ".results")
 
-if ( !file.exists(results_dir) ) {
-  dir.create(results_dir, recursive=TRUE)
+if (!file.exists(results_dir)) {
+  dir.create(results_dir, recursive = TRUE)
 }
 
 ##### Check if spreadsheet with clinical information exists
 clinical_info_file <- params$clinical_info
 runClinicalChunk <- FALSE
 
-if ( file.exists(clinical_info_file) ) {
+if (file.exists(clinical_info_file)) {
   ref_dataset.list[[dataset]][["clinical_info"]] <- read.xlsx(xlsxFile = clinical_info_file, sheet = 1, colNames = TRUE, rowNames = FALSE, detectDates = TRUE, skipEmptyRows = TRUE, skipEmptyCols = TRUE, check.names = TRUE)
   runClinicalChunk <- TRUE
 }
 
 ##### Read in selected genes list
-ref_genes.list[["genes_cancer"]] <- read.table(paste(params$ref_data_dir, params$genes_cancer, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="")
-ref_genes.list[["genes_oncokb"]] <- read.table(paste(params$ref_data_dir, params$oncokb_genes, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="", comment.char = "")
-ref_genes.list[["genes_immune"]]$immune_markers <- read.table(paste(params$ref_data_dir, params$genes_immune_markers, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="")
-ref_genes.list[["genes_hrd"]] <- read.table(paste(params$ref_data_dir, params$genes_hrd, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="")
+ref_genes.list[["genes_cancer"]] <- read.table(paste(params$ref_data_dir, params$genes_cancer, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "")
+ref_genes.list[["genes_oncokb"]] <- read.table(paste(params$ref_data_dir, params$oncokb_genes, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "", comment.char = "")
+ref_genes.list[["genes_immune"]]$immune_markers <- read.table(paste(params$ref_data_dir, params$genes_immune_markers, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "")
+ref_genes.list[["genes_hrd"]] <- read.table(paste(params$ref_data_dir, params$genes_hrd, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "")
 
-if ( params$immunogram ) {
-  ref_genes.list[["genes_immune"]]$immunogram <- read.table(paste(params$ref_data_dir, params$genes_immunogram, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="")
+if (params$immunogram) {
+  ref_genes.list[["genes_immune"]]$immunogram <- read.table(paste(params$ref_data_dir, params$genes_immunogram, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "")
 }
 
 ##### Read in gene fusion data for investigate sample
 ##### Read in arriba and pizzly fusion calls
 ##### Check if arriba output file exists
-if ( !is.null(params$arriba_rnaseq) ) {
-    arribaDir <- params$arriba_rnaseq
+if (!is.null(params$arriba_rnaseq)) {
+  arribaDir <- params$arriba_rnaseq
 } else {
-    arribaDir <- paste(dataDir, "arriba", sep="/")
+  arribaDir <- paste(dataDir, "arriba", sep = "/")
 }
 arriba_file <- paste(arribaDir, "fusions.tsv", sep = "/")
 arriba_pdf <- paste(arribaDir, "fusions.pdf", sep = "/")
 runArribaChunk <- FALSE
 runFusionChunk <- FALSE
 
-if ( file.exists(arriba_file) ) {
+if (file.exists(arriba_file)) {
   ref_genes.list[["arriba"]] <- read.table(file = arriba_file, header = TRUE, comment.char = "", quote = "")
-  
+
   ##### Make sure that at least one fusions has been reported by Arriba
-  if ( nrow(ref_genes.list[["arriba"]]) > 0 ) {
-    
+  if (nrow(ref_genes.list[["arriba"]]) > 0) {
     ##### Convert Arriba pdf booklet with fusion plots to png images
-    if ( file.exists(arriba_pdf) ) {
+    if (file.exists(arriba_pdf)) {
       arriba_plots(arriba_file = arriba_file, arriba_results = ref_genes.list[["arriba"]], results_dir = paste0(results_dir, "/arriba"))
     }
-    
+
     ##### Write list of fusion events for which Arriba plot is available into a file (for PIEdb portal)
     fusion <- gsub(":", ".", c("", paste0(make.names(paste(ref_genes.list[["arriba"]]$X.gene1, ref_genes.list[["arriba"]]$gene2, sep = "__")), "_", ref_genes.list[["arriba"]]$breakpoint1, "-", ref_genes.list[["arriba"]]$breakpoint2)))
-    
-    write.table(prepare2write(fusion), file = paste0(results_dir, "/", params$sample_name, params$dataset_name_incl, ".RNAseq_report.arriba_fusions.txt"), sep="\t", quote=FALSE, row.names=FALSE, col.names=FALSE, append = FALSE )
-  
+
+    write.table(prepare2write(fusion), file = paste0(results_dir, "/", params$sample_name, params$dataset_name_incl, ".RNAseq_report.arriba_fusions.txt"), sep = "\t", quote = FALSE, row.names = FALSE, col.names = FALSE, append = FALSE)
+
     runArribaChunk <- TRUE
     runFusionChunk <- TRUE
-    
   } else {
     ##### Write list of fusion events for which arriba plot is available into a file (for PIEdb portal)
-  write.table(prepare2write(""), file = paste0(results_dir, "/", params$sample_name, params$dataset_name_incl, ".RNAseq_report.arriba_fusions.txt"), sep="\t", quote=FALSE, row.names=FALSE, col.names=FALSE, append = FALSE )
+    write.table(prepare2write(""), file = paste0(results_dir, "/", params$sample_name, params$dataset_name_incl, ".RNAseq_report.arriba_fusions.txt"), sep = "\t", quote = FALSE, row.names = FALSE, col.names = FALSE, append = FALSE)
   }
-  
 } else {
   ##### Write list of fusion events for which arriba plot is available into a file (for PIEdb portal)
-  write.table(prepare2write(""), file = paste0(results_dir, "/", params$sample_name, params$dataset_name_incl, ".RNAseq_report.arriba_fusions.txt"), sep="\t", quote=FALSE, row.names=FALSE, col.names=FALSE, append = FALSE )
+  write.table(prepare2write(""), file = paste0(results_dir, "/", params$sample_name, params$dataset_name_incl, ".RNAseq_report.arriba_fusions.txt"), sep = "\t", quote = FALSE, row.names = FALSE, col.names = FALSE, append = FALSE)
 }
 
 ##### Read in dragen fusion calls
 ##### Check if dragen output file exists
-dragen_fusion_file <- paste(dataDir, list.files(dataDir, pattern="\\.fusion_candidates.final$"), sep = "/")
+dragen_fusion_file <- paste(dataDir, list.files(dataDir, pattern = "\\.fusion_candidates.final$"), sep = "/")
 runDragenFusionChunk <- FALSE
 
-if ( !is.null(params$dragen_rnaseq) && file.exists(dragen_fusion_file) ) {
-  
+if (!is.null(params$dragen_rnaseq) && file.exists(dragen_fusion_file)) {
   ##### Dragen's fusion output file header starts with '#' hence change the comment indicator option to '^' ( https://stackoverflow.com/questions/27196470/reading-a-line-that-starts-with-a-hash-on-a-txt-file )
-  
-  dragen_fusion <- read.table(file = dragen_fusion_file[1], header = TRUE, comment.char = '^', quote = "")
-  
+
+  dragen_fusion <- read.table(file = dragen_fusion_file[1], header = TRUE, comment.char = "^", quote = "")
+
   ##### Check Dragen's fusion format version
   #####  Dragen's fusion format version 3.9.3
-  if ( all(c("X.FusionGene", "Score", "LeftBreakpoint", "RightBreakpoint", "Gene1Location", "Gene2Location", "Gene1Sense", "Gene2Sense", "Gene1Id", "Gene2Id", "NumSplitReads", "NumSoftClippedReads", "NumPairedReads", "ReadNames") %in% colnames(dragen_fusion)) ) {
+  if (all(c("X.FusionGene", "Score", "LeftBreakpoint", "RightBreakpoint", "Gene1Location", "Gene2Location", "Gene1Sense", "Gene2Sense", "Gene1Id", "Gene2Id", "NumSplitReads", "NumSoftClippedReads", "NumPairedReads", "ReadNames") %in% colnames(dragen_fusion))) {
     colnames(dragen_fusion) <- c("FusionGene", "Score", "LeftBreakpoint", "RightBreakpoint", "Gene1Location", "Gene2Location", "Gene1Sense", "Gene2Sense", "Gene1Id", "Gene2Id", "NumSplitReads", "NumSoftClippedReads", "NumPairedReads", "ReadNames")
-  } else if ( all(c("X.FusionGene", "Score", "LeftBreakpoint", "RightBreakpoint", "ReadNames") %in% colnames(dragen_fusion)) ) {
+  } else if (all(c("X.FusionGene", "Score", "LeftBreakpoint", "RightBreakpoint", "ReadNames") %in% colnames(dragen_fusion))) {
     colnames(dragen_fusion) <- c("FusionGene", "Score", "LeftBreakpoint", "RightBreakpoint", "ReadNames")
   }
-  
+
   dragen_fusion_genes <- dragen_fusion %>%
     tidyr::separate(col = FusionGene, into = c("gene1", "gene2"), sep = "--")
-  
+
   ref_genes.list[["dragenFusion"]] <- dragen_fusion_genes
-  
+
   runDragenFusionChunk <- TRUE
   runFusionChunk <- TRUE
 }
@@ -358,11 +350,11 @@ pizzly_file <- paste(dataDir, "pizzly", paste0(params$sample_name, "-flat.tsv"),
 pizzly_file_filtered <- paste(dataDir, "pizzly", paste0(params$sample_name, "-flat-filtered.tsv"), sep = "/")
 runPizzlyChunk <- FALSE
 
-if ( !is.null(params$bcbio_rnaseq) &&  file.exists(pizzly_file) ) {
+if (!is.null(params$bcbio_rnaseq) && file.exists(pizzly_file)) {
   ref_genes.list[["pizzly"]] <- read.table(file = pizzly_file, header = TRUE, quote = "")
   runPizzlyChunk <- TRUE
   runFusionChunk <- TRUE
-} else if ( file.exists(pizzly_file_filtered) ) {
+} else if (file.exists(pizzly_file_filtered)) {
   ref_genes.list[["pizzly"]] <- read.table(file = pizzly_file_filtered, header = TRUE, quote = "")
   runPizzlyChunk <- TRUE
   runFusionChunk <- TRUE
@@ -370,84 +362,81 @@ if ( !is.null(params$bcbio_rnaseq) &&  file.exists(pizzly_file) ) {
 
 ##### Read in mutation data for investigate sample
 ##### Get the genomic output data from umccrise
-if ( !is.null(params$umccrise) ) {
-  umccrise <- unlist(strsplit(params$umccrise, split='/', fixed=TRUE))
+if (!is.null(params$umccrise)) {
+  umccrise <- unlist(strsplit(params$umccrise, split = "/", fixed = TRUE))
   umccrise <- umccrise[length(umccrise)]
-  
+
   ##### Check if PCGR (mutation) output file exists
   runPcgrChunk <- TRUE
-  
-  if ( file.exists(paste(params$umccrise, "small_variants", paste0(umccrise, "-somatic.pcgr.snvs_indels.tiers.tsv"), sep = "/")) ) {
+
+  if (file.exists(paste(params$umccrise, "small_variants", paste0(umccrise, "-somatic.pcgr.snvs_indels.tiers.tsv"), sep = "/"))) {
     pcgr_file <- paste(params$umccrise, "small_variants", paste0(umccrise, "-somatic.pcgr.snvs_indels.tiers.tsv"), sep = "/")
-  } else if ( file.exists(paste(params$umccrise, "..", "work", umccrise, "pcgr", paste0(umccrise, "-somatic.pcgr.snvs_indels.tiers.tsv"), sep = "/")) ) {
+  } else if (file.exists(paste(params$umccrise, "..", "work", umccrise, "pcgr", paste0(umccrise, "-somatic.pcgr.snvs_indels.tiers.tsv"), sep = "/"))) {
     pcgr_file <- paste(params$umccrise, "..", "work", umccrise, "pcgr", paste0(umccrise, "-somatic.pcgr.snvs_indels.tiers.tsv"), sep = "/")
-  } else if ( file.exists(paste(params$umccrise, "pcgr", paste0(umccrise, "-somatic.pcgr.snvs_indels.tiers.tsv"), sep = "/")) ) {
+  } else if (file.exists(paste(params$umccrise, "pcgr", paste0(umccrise, "-somatic.pcgr.snvs_indels.tiers.tsv"), sep = "/"))) {
     pcgr_file <- paste(params$umccrise, "pcgr", paste0(umccrise, "-somatic.pcgr.snvs_indels.tiers.tsv"), sep = "/")
-  } else if ( file.exists(paste(params$umccrise, "pcgr", paste0(umccrise, "-somatic.pcgr_acmg.grch37.snvs_indels.tiers.tsv"), sep = "/")) ) {
+  } else if (file.exists(paste(params$umccrise, "pcgr", paste0(umccrise, "-somatic.pcgr_acmg.grch37.snvs_indels.tiers.tsv"), sep = "/"))) {
     pcgr_file <- paste(params$umccrise, "pcgr", paste0(umccrise, "-somatic.pcgr_acmg.grch37.snvs_indels.tiers.tsv"), sep = "/")
   } else {
     runPcgrChunk <- FALSE
   }
-  
-  if ( runPcgrChunk ) {
-    ref_genes.list[["pcgr"]] <- read.table(pcgr_file, sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, fill = TRUE, quote = "")
-    
+
+  if (runPcgrChunk) {
+    ref_genes.list[["pcgr"]] <- read.table(pcgr_file, sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, fill = TRUE, quote = "")
+
     ##### Simplify the variants types
     ref_genes.list[["pcgr"]]$CONSEQUENCE <- gsub("_variant", "", ref_genes.list[["pcgr"]]$CONSEQUENCE)
     ref_genes.list[["pcgr"]]$CONSEQUENCE <- gsub("_", " ", ref_genes.list[["pcgr"]]$CONSEQUENCE)
-    
+
     ##### Simplify tiers' annotations and AFs
     ref_genes.list[["pcgr"]]$TIER <- gsub("TIER ", "", ref_genes.list[["pcgr"]]$TIER)
     ref_genes.list[["pcgr"]]$AF_TUMOR <- round(ref_genes.list[["pcgr"]]$AF_TUMOR, digits = 2)
   } else {
     ref_genes.list[["pcgr"]] <- NULL
   }
-  
+
   ##### Check if purple (CN) output file exists
   purple_file_1 <- paste(params$umccrise, "purple", paste0(umccrise, ".purple.gene.cnv"), sep = "/")
   purple_file_2 <- paste(params$umccrise, "purple", paste0(umccrise, ".purple.cnv.gene.tsv"), sep = "/")
   runPurpleChunk <- TRUE
-  
-  if ( file.exists(purple_file_1) ) {
-    ref_genes.list[["purple"]] <- read.table(purple_file_1, sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, fill = TRUE, quote = "")
-  } else if ( file.exists(purple_file_2) ) {
-    ref_genes.list[["purple"]] <- read.table(purple_file_2, sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, fill = TRUE, quote = "")
+
+  if (file.exists(purple_file_1)) {
+    ref_genes.list[["purple"]] <- read.table(purple_file_1, sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, fill = TRUE, quote = "")
+  } else if (file.exists(purple_file_2)) {
+    ref_genes.list[["purple"]] <- read.table(purple_file_2, sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, fill = TRUE, quote = "")
     colnames(ref_genes.list[["purple"]]) <- sapply(colnames(ref_genes.list[["purple"]]), CapStr)
   } else {
     ref_genes.list[["purple"]] <- NULL
     runPurpleChunk <- FALSE
   }
-  
+
   ##### Check if manta (structural variants (SVs)) file exists
   sv_file_1 <- paste(params$umccrise, "structural", paste0(umccrise, "-sv-prioritize-manta-pass.tsv"), sep = "/")
   sv_file_2 <- paste(params$umccrise, "structural", paste0(umccrise, "-manta.tsv"), sep = "/")
   runSVsChunk <- TRUE
-  
-  if ( file.exists(sv_file_1) ) {
+
+  if (file.exists(sv_file_1)) {
     ref_genes.list[["manta"]] <- sv_prioritize_short(sv_file_1)
-  } else if ( file.exists(sv_file_2) ) {
+  } else if (file.exists(sv_file_2)) {
     ref_genes.list[["manta"]] <- sv_prioritize(sv_file_2)
     ref_genes.list[["manta"]] <- ref_genes.list[["manta"]][, c("Tier", "Event", "Gene", "Effect", "Detail", "Location", "AF", "CN chg", "SR", "PR", "CN", "Ploidy", "Transcript", "Other effects")]
-    
+
     ##### Check if there are any SVs
-    if ( !is.null(ref_genes.list[["manta"]]) ) {
-      
+    if (!is.null(ref_genes.list[["manta"]])) {
       ##### Omit SVs without assigned gene
-      ref_genes.list[["manta"]] <- ref_genes.list[["manta"]][ ref_genes.list[["manta"]]$Gene != "",  ]
+      ref_genes.list[["manta"]] <- ref_genes.list[["manta"]][ref_genes.list[["manta"]]$Gene != "", ]
     } else {
       ##### Create empty dataframe
       ref_genes.list[["manta"]] <- data.frame(matrix(ncol = 14, nrow = 0))
       colnames(ref_genes.list[["manta"]]) <- c("Tier", "Event", "Gene", "Effect", "Detail", "Location", "AF", "CN chg", "SR", "PR", "CN", "Ploidy", "Transcript", "Other effects")
     }
-    
   } else {
     ref_genes.list[["manta"]] <- NULL
     runSVsChunk <- FALSE
   }
-  
+
   ##### Extract subject ID (part of the umccrise output folder name) and add it to the MySQL insert command. This will overwrite argument passed to "--clinical_id" flag
-  subjectID <- unlist(strsplit(tail(unlist(strsplit(params$umccrise, split='/', fixed=TRUE)), n=1), split='__', fixed=TRUE))[1]
-  
+  subjectID <- unlist(strsplit(tail(unlist(strsplit(params$umccrise, split = "/", fixed = TRUE)), n = 1), split = "__", fixed = TRUE))[1]
 } else {
   runPcgrChunk <- FALSE
   runPurpleChunk <- FALSE
@@ -455,45 +444,44 @@ if ( !is.null(params$umccrise) ) {
 }
 
 ##### Read in OncoKB (http://oncokb.org) annotations
-caner_genes_annot.list[["oncokb_clin_vars"]] <- read.table(paste(params$ref_data_dir, params$oncokb_clin_vars, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="")
-caner_genes_annot.list[["oncokb_all_vars"]] <- read.table(paste(params$ref_data_dir, params$oncokb_all_vars, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="", fill = TRUE)
+caner_genes_annot.list[["oncokb_clin_vars"]] <- read.table(paste(params$ref_data_dir, params$oncokb_clin_vars, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "")
+caner_genes_annot.list[["oncokb_all_vars"]] <- read.table(paste(params$ref_data_dir, params$oncokb_all_vars, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "", fill = TRUE)
 
 ##### Read in CIViC (https://civicdb.org/) annotations
-caner_genes_annot.list[["civic_var_summaries"]] <- read.table(paste(params$ref_data_dir, params$civic_var_summaries, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="", fill = TRUE)
-caner_genes_annot.list[["civic_clin_evid"]] <- read.table(paste(params$ref_data_dir, params$civic_clin_evid, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="", fill = TRUE)
+caner_genes_annot.list[["civic_var_summaries"]] <- read.table(paste(params$ref_data_dir, params$civic_var_summaries, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "", fill = TRUE)
+caner_genes_annot.list[["civic_clin_evid"]] <- read.table(paste(params$ref_data_dir, params$civic_clin_evid, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "", fill = TRUE)
 
 ##### Read in Cancer Biomarkers database (https://www.cancergenomeinterpreter.org/biomarkers) annotations. This is mainly used to annotate reported fusion events
-caner_genes_annot.list[["cancer_biomarkers_trans"]] <- read.table(paste(params$ref_data_dir, params$cancer_biomarkers_trans, sep="/"), sep="\t", as.is=TRUE, header=TRUE, row.names=NULL, quote="", fill = TRUE)
+caner_genes_annot.list[["cancer_biomarkers_trans"]] <- read.table(paste(params$ref_data_dir, params$cancer_biomarkers_trans, sep = "/"), sep = "\t", as.is = TRUE, header = TRUE, row.names = NULL, quote = "", fill = TRUE)
 
 ##### Read in FusionGDB database (https://ccsm.uth.edu/FusionGDB/) used to annotate reported fusion events, with info about head and tail genes.
-caner_genes_annot.list[["FusionGDB"]] <- read.table(paste(params$ref_data_dir, params$FusionGDB, sep="/"), sep="\t", as.is=TRUE, header=FALSE, row.names=NULL, quote="", fill = TRUE)
+caner_genes_annot.list[["FusionGDB"]] <- read.table(paste(params$ref_data_dir, params$FusionGDB, sep = "/"), sep = "\t", as.is = TRUE, header = FALSE, row.names = NULL, quote = "", fill = TRUE)
 names(caner_genes_annot.list[["FusionGDB"]]) <- c("Hgene", "HgeneID", "Tgene", "TgeneID", "FGname", "FGID")
 
 
 ##### Add refenence cohort name to the sample name
-if ( params$dataset_name_incl != "" ) {
+if (params$dataset_name_incl != "") {
   sample_name <- paste0(params$sample_name, "_", params$dataset)
 } else {
   sample_name <- params$sample_name
 }
 
 ##### Read in reference datasets and merge them with sample data. This part outputs a vector with first element containing the merged data and second element containing merged targets info
-ref_dataset.list[[dataset]] <- combineDatasets(sample_name=sample_name, sample_counts=counts, ref_data=ref_dataset, report_dir = results_dir, dataset = dataset)
+ref_dataset.list[[dataset]] <- combineDatasets(sample_name = sample_name, sample_counts = counts, ref_data = ref_dataset, report_dir = results_dir, dataset = dataset)
 names(ref_dataset.list[[dataset]]) <- c("combined_data", "sample_annot")
 
 ##### Define internal, external and addition cancer group names based on the targets definition
 int_cancer_group <- ref_dataset$int_ref[3]
 ext_cancer_group <- ref_dataset$ext_ref[3]
 
-if ( length(unique(ref_dataset.list[[dataset]][["sample_annot"]]$Target)) > 3 ) {
-  
+if (length(unique(ref_dataset.list[[dataset]][["sample_annot"]]$Target)) > 3) {
   add_cancer_group <- unique(ref_dataset.list[[dataset]][["sample_annot"]]$Target)[2]
 } else {
   add_cancer_group <- NULL
 }
 
 ##### Define the cancer group to be used to compare per-gene expression values and report in the summary tables
-if ( dataset == "PAAD" || dataset == "PAAD-IPMN" || dataset == "PAAD-NET" || dataset == "PAAD-ACC" ) {
+if (dataset == "PAAD" || dataset == "PAAD-IPMN" || dataset == "PAAD-NET" || dataset == "PAAD-ACC") {
   comp_cancer_group <- int_cancer_group
 } else {
   comp_cancer_group <- ext_cancer_group
@@ -509,36 +497,35 @@ mysql_populate <- paste0("### MySQL command to insert data for sample \"", sampl
 mysql_populate_update <- "ON DUPLICATE KEY UPDATE ID=1000000 ,Platform=\"RNA_seq\""
 
 ##### Update MySQL commend to populate RNA-seq data portal
-mysql_populate <- paste0(mysql_populate, ", \"", subjectID, "\", \"", sample_name, "\", \"", params$dataset , "\", \"", params$sample_source , "\", \"", params$project , "\", \"", paste0(sample_name, ".RNAseq_report.html"), "\", \"", sample_name, "\", \""  )
-mysql_populate_update <-  paste0(mysql_populate_update, ", PatientID=\"", subjectID, "\", SampleID=\"", sample_name, "\", Cancer=\"", params$dataset , "\", Source=\"", params$sample_source , "\", Project=\"", params$project , "\", Report=\"", paste0(sample_name, ".RNAseq_report.html"),"\", PMID=\"", sample_name, "\", Analysis=\""  )
+mysql_populate <- paste0(mysql_populate, ", \"", subjectID, "\", \"", sample_name, "\", \"", params$dataset, "\", \"", params$sample_source, "\", \"", params$project, "\", \"", paste0(sample_name, ".RNAseq_report.html"), "\", \"", sample_name, "\", \"")
+mysql_populate_update <- paste0(mysql_populate_update, ", PatientID=\"", subjectID, "\", SampleID=\"", sample_name, "\", Cancer=\"", params$dataset, "\", Source=\"", params$sample_source, "\", Project=\"", params$project, "\", Report=\"", paste0(sample_name, ".RNAseq_report.html"), "\", PMID=\"", sample_name, "\", Analysis=\"")
 ```
 
 ```{r treatment_info, comment = NA, message=FALSE, warning=FALSE, fig.width = 12, fig.height = 5, eval = runClinicalChunk }
 ##### Prapare data for the treatment timeline plot
 ##### Search for row with clinical info for investigated patient
-if ( !is.na(params$clinical_id) ) {
+if (!is.na(params$clinical_id)) {
   sampleID.col <- grep(params$clinical_id, ref_dataset.list[[dataset]][["clinical_info"]])
-} else if ( !is.na(params$subject_id) ) {
+} else if (!is.na(params$subject_id)) {
   sampleID.col <- grep(params$subject_id, ref_dataset.list[[dataset]][["clinical_info"]])
-} else if ( !is.na(subjectID) ) {
+} else if (!is.na(subjectID)) {
   sampleID.col <- grep(subjectID, ref_dataset.list[[dataset]][["clinical_info"]])
 }
 
 runClinicalChunk <- FALSE
 
-if ( length(sampleID.col) > 0 ) {
-  
+if (length(sampleID.col) > 0) {
   ##### Identify column and row with patients details
-  if ( !is.na(params$clinical_id) ) {
+  if (!is.na(params$clinical_id)) {
     sampleID.row <- grep(params$clinical_id, ref_dataset.list[[dataset]][["clinical_info"]][, sampleID.col])
-  } else if ( !is.na(params$subject_id) ) {
+  } else if (!is.na(params$subject_id)) {
     sampleID.row <- grep(params$subject_id, ref_dataset.list[[dataset]][["clinical_info"]][, sampleID.col])
-  } else if ( !is.na(subjectID) ) {
+  } else if (!is.na(subjectID)) {
     sampleID.row <- grep(subjectID, ref_dataset.list[[dataset]][["clinical_info"]][, sampleID.col])
   }
-  
-  clinical_info <- ref_dataset.list[[dataset]][["clinical_info"]][ sampleID.row, ]
-  
+
+  clinical_info <- ref_dataset.list[[dataset]][["clinical_info"]][sampleID.row, ]
+
   ##### Prepare data frame structure for plotting
   ##### Define treatment types
   treamtent.types <- make.names(c("NEOADJUVANT REGIMEN", "ADJUVANT REGIMEN", "FIRST LINE REGIMEN", "SECOND LINE REGIMEN", "THIRD LINE REGIMEN"))
@@ -546,31 +533,29 @@ if ( length(sampleID.col) > 0 ) {
   treamtent.df <- data.frame(matrix(ncol = 4, nrow = 0))
   colnames(treamtent.df) <- c("Treatment", "Type", "Start", "End")
 
-  for ( i in 1:length(treamtent.types) ) {
-    
+  for (i in 1:length(treamtent.types)) {
     ##### Identify treatment column number
-    treamtent.types.col <- grep(paste0("^",treamtent.types[i], "$"), names(clinical_info))
-    
+    treamtent.types.col <- grep(paste0("^", treamtent.types[i], "$"), names(clinical_info))
+
     ##### Check how many treatments of particular type were used
-    treamtent.types.details <- unlist(strsplit(clinical_info[, treamtent.types.col], split=',', fixed=TRUE))
-    
+    treamtent.types.details <- unlist(strsplit(clinical_info[, treamtent.types.col], split = ",", fixed = TRUE))
+
     ##### Add start and end info for each treatment
-    if ( any(!is.na(treamtent.types.details ), na.rm = FALSE) ) {
-      for ( treatment in treamtent.types.details ) {
-        
-        treamtent.start <- clinical_info[, treamtent.types.col+1]
-        treamtent.end <- clinical_info[, treamtent.types.col+2]
+    if (any(!is.na(treamtent.types.details), na.rm = FALSE)) {
+      for (treatment in treamtent.types.details) {
+        treamtent.start <- clinical_info[, treamtent.types.col + 1]
+        treamtent.end <- clinical_info[, treamtent.types.col + 2]
 
         ##### Use current data if treatment is still ongoing
         today <- as.character(Sys.Date())
-        treamtent.end[ is.na(treamtent.end) ] <- today
-        treamtent.tmp <- data.frame( treatment, treatment, treamtent.types_simple[i], treamtent.start, treamtent.end)
-        treamtent.df <- rbind( treamtent.df, treamtent.tmp)
+        treamtent.end[is.na(treamtent.end)] <- today
+        treamtent.tmp <- data.frame(treatment, treatment, treamtent.types_simple[i], treamtent.start, treamtent.end)
+        treamtent.df <- rbind(treamtent.df, treamtent.tmp)
       }
     }
   }
-  
-  if ( nrow(treamtent.df) > 0 ) {
+
+  if (nrow(treamtent.df) > 0) {
     ##### For security reasons (wrt plots that go to PIEdb), change the dates but preserve the duration of the treatments
     ##### Get the earliest treatment date and set it as day 0. Then, create fake start and end dates based on the treatment length
     day0 <- sort(treamtent.df$treamtent.start, decreasing = FALSE)[1]
@@ -578,43 +563,43 @@ if ( length(sampleID.col) > 0 ) {
     treamtents.reset <- as.Date("2000-01-01") - day0
     treamtent.df$treamtent.start <- treamtent.df$treamtent.start + treamtents.reset
     treamtent.df$treamtent.end <- treamtent.df$treamtent.start + treamtents.length
-    names(treamtent.df) <- c("Treatment", "Drug", "Type", "Start",  "End")
-    
+    names(treamtent.df) <- c("Treatment", "Drug", "Type", "Start", "End")
+
     ##### Create directory for timeline plot
     PlotsDir <- paste(results_dir, "clinical_info", sep = "/")
-    if ( !file.exists(PlotsDir) ) {
-      dir.create(PlotsDir, recursive=TRUE)
+    if (!file.exists(PlotsDir)) {
+      dir.create(PlotsDir, recursive = TRUE)
     }
-        
+
     ##### Record the timeline plot. NOTE, the modified dates are used here
     treatment_timeline <- lares::plot_timeline(event = treamtent.df$Treatment, start = treamtent.df$Start, end = treamtent.df$End, label = NA, group = treamtent.df$Type, title = "", subtitle = "", save = FALSE)
-    
+
     ##### Save the plot into png file. NOTE, the modified dates are used here. As default, the plot is saved as "cv_timeline"
     lares::plot_timeline(event = treamtent.df$Treatment, start = treamtent.df$Start, end = treamtent.df$End, label = NA, group = treamtent.df$Type, title = "", subtitle = "", save = TRUE, subdir = "clinical_info")
-    
+
     #### Clear plots to free up some memory
-    if(!is.null(dev.list())) invisible(dev.off())
-    
+    if (!is.null(dev.list())) invisible(dev.off())
+
     cv_timeline.png <- readPNG("clinical_info/cv_timeline.png", native = FALSE, info = FALSE)
-    
+
     ##### Change the size of the timeline png plot and save it as "treatment_timeline.png"
-    png::writePNG(cv_timeline.png, paste(PlotsDir, "treatment_timeline.png", sep="/"), dpi=300)
-    #png(paste(PlotsDir, "treatment_timeline.png", sep="/"), width = 900, height = 600, pointsize = 0.0001, res=300)
-    #plot(cv_timeline.png)
-    #invisible(dev.off())
-    
+    png::writePNG(cv_timeline.png, paste(PlotsDir, "treatment_timeline.png", sep = "/"), dpi = 300)
+    # png(paste(PlotsDir, "treatment_timeline.png", sep="/"), width = 900, height = 600, pointsize = 0.0001, res=300)
+    # plot(cv_timeline.png)
+    # invisible(dev.off())
+
     #### Clear plots to free up some memory
-    if(!is.null(dev.list())) invisible(dev.off())
-    
+    if (!is.null(dev.list())) invisible(dev.off())
+
     ##### Remove the original plot folder
     system("rm -rf clinical_info", ignore.stdout = TRUE, ignore.stderr = TRUE)
-    
+
     runClinicalChunk <- TRUE
   }
 
-##### Clean the space
-rm(list = ls(pattern='^treamtent.*'))
-rm(clinical_info, cv_timeline.png)
+  ##### Clean the space
+  rm(list = ls(pattern = "^treamtent.*"))
+  rm(clinical_info, cv_timeline.png)
 }
 ```
 
@@ -637,37 +622,36 @@ ref_genes.list[["genes_cancer"]]$tumorsuppressor <- gsub("FALSE", "-", ref_genes
 ref_genes.list[["genes_cancer"]]$oncogene <- gsub("TRUE", "Yes", ref_genes.list[["genes_cancer"]]$oncogene)
 ref_genes.list[["genes_cancer"]]$oncogene <- gsub("FALSE", "-", ref_genes.list[["genes_cancer"]]$oncogene)
 
-for ( gene in unlist(ref_genes.list[["genes_cancer"]]$symbol ) ) {
+for (gene in unlist(ref_genes.list[["genes_cancer"]]$symbol)) {
   ##### Check if the UMCCR genes is already reported in OncoKB
-  if ( gene %in% genes_cancer$Hugo.Symbol ) {
-   
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, ]$UMCCR <- "Yes"
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, ]$Oncogene <- ref_genes.list[["genes_cancer"]]$oncogene[ref_genes.list[[ "genes_cancer"]]$symbol==gene]
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, ]$TSG <- ref_genes.list[["genes_cancer"]]$tumorsuppressor[ref_genes.list[[ "genes_cancer"]]$symbol==gene]
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, ]$Fusion <- ref_genes.list[["genes_cancer"]]$fusion[ref_genes.list[[ "genes_cancer"]]$symbol==gene]
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, ]$Germline <- ref_genes.list[["genes_cancer"]]$germ[ref_genes.list[[ "genes_cancer"]]$symbol==gene]
-    
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, 2] <- as.numeric(genes_cancer[ genes_cancer$Hugo.Symbol==gene, 2]) + 1
-    
-  ##### Add if not present
+  if (gene %in% genes_cancer$Hugo.Symbol) {
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, ]$UMCCR <- "Yes"
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, ]$Oncogene <- ref_genes.list[["genes_cancer"]]$oncogene[ref_genes.list[["genes_cancer"]]$symbol == gene]
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, ]$TSG <- ref_genes.list[["genes_cancer"]]$tumorsuppressor[ref_genes.list[["genes_cancer"]]$symbol == gene]
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, ]$Fusion <- ref_genes.list[["genes_cancer"]]$fusion[ref_genes.list[["genes_cancer"]]$symbol == gene]
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, ]$Germline <- ref_genes.list[["genes_cancer"]]$germ[ref_genes.list[["genes_cancer"]]$symbol == gene]
+
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, 2] <- as.numeric(genes_cancer[genes_cancer$Hugo.Symbol == gene, 2]) + 1
+
+    ##### Add if not present
   } else {
     genes_cancer <- rbind(genes_cancer, c(gene, 1, "No", rep("", 8), "Yes"))
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, ]$Oncogene <- ref_genes.list[["genes_cancer"]]$oncogene[ref_genes.list[[ "genes_cancer"]]$symbol==gene]
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, ]$TSG <- ref_genes.list[["genes_cancer"]]$tumorsuppressor[ref_genes.list[[ "genes_cancer"]]$symbol==gene]
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, ]$Fusion <- ref_genes.list[["genes_cancer"]]$fusion[ref_genes.list[[ "genes_cancer"]]$symbol==gene]
-    genes_cancer[ genes_cancer$Hugo.Symbol==gene, ]$Germline <- ref_genes.list[["genes_cancer"]]$germ[ref_genes.list[[ "genes_cancer"]]$symbol==gene]
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, ]$Oncogene <- ref_genes.list[["genes_cancer"]]$oncogene[ref_genes.list[["genes_cancer"]]$symbol == gene]
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, ]$TSG <- ref_genes.list[["genes_cancer"]]$tumorsuppressor[ref_genes.list[["genes_cancer"]]$symbol == gene]
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, ]$Fusion <- ref_genes.list[["genes_cancer"]]$fusion[ref_genes.list[["genes_cancer"]]$symbol == gene]
+    genes_cancer[genes_cancer$Hugo.Symbol == gene, ]$Germline <- ref_genes.list[["genes_cancer"]]$germ[ref_genes.list[["genes_cancer"]]$symbol == gene]
   }
 }
 
 ##### Make the data frame to look nicer
 rownames(genes_cancer) <- genes_cancer$Hugo.Symbol
 names(genes_cancer) <- c("Gene", "Gene panels no.", "OncoKB", "Oncogene (OncoKB)", "TSG (OncoKB)", "MSK-IMPACT", "MSK-HEME", "Foundation One", "Foundation One Heme", "Vogelstein", "Sanger CGC", "UMCCR", "Oncogene", "TSG", "Fusion", "Germline")
-genes_cancer <- genes_cancer[,c("Oncogene", "TSG", "Fusion", "Germline", "Gene panels no.", "UMCCR", "OncoKB", "MSK-IMPACT", "MSK-HEME", "Foundation One", "Foundation One Heme", "Vogelstein", "Sanger CGC")]
-genes_cancer[ genes_cancer=="No" ] <- "-"
-genes_cancer[ genes_cancer=="" ] <- "-"
+genes_cancer <- genes_cancer[, c("Oncogene", "TSG", "Fusion", "Germline", "Gene panels no.", "UMCCR", "OncoKB", "MSK-IMPACT", "MSK-HEME", "Foundation One", "Foundation One Heme", "Vogelstein", "Sanger CGC")]
+genes_cancer[genes_cancer == "No"] <- "-"
+genes_cancer[genes_cancer == ""] <- "-"
 
 ref_genes.list[["genes_cancer"]] <- genes_cancer
-ref_genes.list[["genes_oncokb"]] <- genes_cancer[ rownames(genes_cancer) %in% ref_genes.list[["genes_oncokb"]]$Hugo.Symbol, ]
+ref_genes.list[["genes_oncokb"]] <- genes_cancer[rownames(genes_cancer) %in% ref_genes.list[["genes_oncokb"]]$Hugo.Symbol, ]
 
 ##### Clean the space
 rm(genes_cancer)
@@ -676,98 +660,96 @@ rm(genes_cancer)
 ```{r goi_summary, comment = NA, message=FALSE, warning=FALSE}
 ##### Record all genes of interest to make sure that these are not filtered out during read counts data processing
 # PCGR annotation of mutated genes in given patient based on PCGR report, including only those with variants classified according to user-defined tier
-if ( runPcgrChunk ) {
-  ref_genes.list[["summary"]]$Mutated <- unique(ref_genes.list[["pcgr"]][ ref_genes.list[["pcgr"]]$TIER %in% c(1:params$pcgr_tier), ]$SYMBOL)
-  
+if (runPcgrChunk) {
+  ref_genes.list[["summary"]]$Mutated <- unique(ref_genes.list[["pcgr"]][ref_genes.list[["pcgr"]]$TIER %in% c(1:params$pcgr_tier), ]$SYMBOL)
+
   ##### Include splice region variants
-  if ( params$pcgr_splice_vars ) {
-    ref_genes.list[["summary"]]$Mutated <- unique( c(ref_genes.list[["summary"]]$Mutated,  ref_genes.list[["pcgr"]][ grepl("NONCODING.*splice region", paste0(ref_genes.list[["pcgr"]]$TIER, ".", ref_genes.list[["pcgr"]]$CONSEQUENCE), fixed = FALSE), ]$SYMBOL) )
+  if (params$pcgr_splice_vars) {
+    ref_genes.list[["summary"]]$Mutated <- unique(c(ref_genes.list[["summary"]]$Mutated, ref_genes.list[["pcgr"]][grepl("NONCODING.*splice region", paste0(ref_genes.list[["pcgr"]]$TIER, ".", ref_genes.list[["pcgr"]]$CONSEQUENCE), fixed = FALSE), ]$SYMBOL))
   }
-  
+
   ##### Remove NAs
-  if ( length(ref_genes.list[["summary"]]$Mutated) > 0 ) {
-    ref_genes.list[["summary"]]$Mutated <- ref_genes.list[["summary"]]$Mutated[ !(is.na(ref_genes.list[["summary"]]$Mutated)) ]
+  if (length(ref_genes.list[["summary"]]$Mutated) > 0) {
+    ref_genes.list[["summary"]]$Mutated <- ref_genes.list[["summary"]]$Mutated[!(is.na(ref_genes.list[["summary"]]$Mutated))]
   } else {
     ref_genes.list[["summary"]]$Mutated <- NULL
   }
 }
-    
+
 # ARRIBA and PIZZLY annotation of gene fusion events detected in given patient based on PIZZLY results
-if ( runFusionChunk ) {
-  
-  if ( runArribaChunk ) {
+if (runFusionChunk) {
+  if (runArribaChunk) {
     ref_genes.list[["summary"]]$Fusion <- unique(c(as.character(ref_genes.list[["arriba"]]$X.gene1), as.character(ref_genes.list[["arriba"]]$gene2)))
   } else {
     ref_genes.list[["summary"]]$Fusion <- NULL
   }
-  
-  if ( runPizzlyChunk ) {
+
+  if (runPizzlyChunk) {
     ref_genes.list[["summary"]]$Fusion <- unique(c(ref_genes.list[["summary"]]$Fusion, as.character(ref_genes.list[["pizzly"]]$geneA.name), as.character(ref_genes.list[["pizzly"]]$geneB.name)))
   }
-  
-  if ( runDragenFusionChunk ) {
+
+  if (runDragenFusionChunk) {
     ref_genes.list[["summary"]]$Fusion <- unique(c(ref_genes.list[["summary"]]$Fusion, as.character(ref_genes.list[["dragenFusion"]]$gene1), as.character(ref_genes.list[["dragenFusion"]]$gene2)))
   }
-  
+
   ##### Remove NAs
-  if ( length(ref_genes.list[["summary"]]$Mutated) > 0 ) {
-    ref_genes.list[["summary"]]$Fusion <- ref_genes.list[["summary"]]$Fusion[ !(is.na(ref_genes.list[["summary"]]$Fusion)) ]
+  if (length(ref_genes.list[["summary"]]$Mutated) > 0) {
+    ref_genes.list[["summary"]]$Fusion <- ref_genes.list[["summary"]]$Fusion[!(is.na(ref_genes.list[["summary"]]$Fusion))]
   } else {
     ref_genes.list[["summary"]]$Fusion <- NULL
   }
 }
 
 # MANTA annotation of structural variants (SVs) with affected genes in given patient based on MANTA results
-if ( runSVsChunk ) {
+if (runSVsChunk) {
   ref_genes.list[["summary"]]$SV <- ref_genes.list[["manta"]]
-  ref_genes.list[["summary"]]$SV <- ref_genes.list[["summary"]]$SV[ ref_genes.list[["summary"]]$SV$Gene != "",  ]$Gene
+  ref_genes.list[["summary"]]$SV <- ref_genes.list[["summary"]]$SV[ref_genes.list[["summary"]]$SV$Gene != "", ]$Gene
   # ...and distinguish classified by MANTA as fusion genes
-  
+
   ##### Remove NAs
-  if ( length(ref_genes.list[["summary"]]$SV) > 0 ) {
-    ref_genes.list[["summary"]]$SV <- unique(unlist(strsplit(ref_genes.list[["summary"]]$SV, split='&', fixed=TRUE)))
-    ref_genes.list[["summary"]]$SV <- ref_genes.list[["summary"]]$SV[ !(is.na(ref_genes.list[["summary"]]$SV)) ]
+  if (length(ref_genes.list[["summary"]]$SV) > 0) {
+    ref_genes.list[["summary"]]$SV <- unique(unlist(strsplit(ref_genes.list[["summary"]]$SV, split = "&", fixed = TRUE)))
+    ref_genes.list[["summary"]]$SV <- ref_genes.list[["summary"]]$SV[!(is.na(ref_genes.list[["summary"]]$SV))]
   } else {
     ref_genes.list[["summary"]]$SV <- NULL
   }
 }
 
 # PURPLE annotation of copy-number (CN) altered genes in given patient based on PURPLE results, including only those with CN values meeting user-defined thresholds
-if ( runPurpleChunk ) {
+if (runPurpleChunk) {
   ref_genes.list[["summary"]]$CN <- ref_genes.list[["purple"]]
-  ref_genes.list[["summary"]]$CN <- ref_genes.list[["summary"]]$CN[ ref_genes.list[["summary"]]$CN %!in% "",  ]
-  
+  ref_genes.list[["summary"]]$CN <- ref_genes.list[["summary"]]$CN[ref_genes.list[["summary"]]$CN %!in% "", ]
+
   ##### Get the CN mean
   ref_genes.list[["summary"]]$CN$MeanCopyNumber <- rowMeans(cbind(ref_genes.list[["summary"]]$CN$MinCopyNumber, ref_genes.list[["summary"]]$CN$MaxCopyNumber))
-    
+
   ##### Deal with negative CN values
-  ref_genes.list[["summary"]]$CN$MeanCopyNumber[ ref_genes.list[["summary"]]$CN$MeanCopyNumber < 0 ] <- 0
+  ref_genes.list[["summary"]]$CN$MeanCopyNumber[ref_genes.list[["summary"]]$CN$MeanCopyNumber < 0] <- 0
 
   ##### Limit the data to include only cancer genes
-  ref_genes.list[["summary"]]$CN <- ref_genes.list[["summary"]]$CN[ ref_genes.list[["summary"]]$CN$Gene %in% rownames(ref_genes.list[["genes_cancer"]]), ]
+  ref_genes.list[["summary"]]$CN <- ref_genes.list[["summary"]]$CN[ref_genes.list[["summary"]]$CN$Gene %in% rownames(ref_genes.list[["genes_cancer"]]), ]
 
   ##### Keep only altered genes with CN values below loss threshold (default 5th percentile) and above gain threshold (default 95th percentile)
-  if ( params$cn_loss == 5 && params$cn_gain == 95 ) {
+  if (params$cn_loss == 5 && params$cn_gain == 95) {
     cn_data.all.percent <- quantile(ref_genes.list[["summary"]]$CN$MeanCopyNumber, probs = seq(0, 1, .05), na.rm = TRUE)
     cn_bottom <- round(cn_data.all.percent[2], digits = 2)
     cn_top <- round(cn_data.all.percent[20], digits = 2)
-  
   } else {
     cn_bottom <- params$cn_loss
     cn_top <- params$cn_gain
   }
-  
+
   ##### If the difference is 0 then increase/decrease threshold by 1
-  if  ( abs(cn_top-cn_bottom) == 0 ) {
+  if (abs(cn_top - cn_bottom) == 0) {
     cn_top <- cn_top + 1
     cn_bottom <- cn_bottom - 1
   }
-  
-  ref_genes.list[["summary"]]$CN <- unique(ref_genes.list[["summary"]]$CN[ ref_genes.list[["summary"]]$CN$MeanCopyNumber <= cn_bottom | ref_genes.list[["summary"]]$CN$MeanCopyNumber >= cn_top, ]$Gene)
-  
+
+  ref_genes.list[["summary"]]$CN <- unique(ref_genes.list[["summary"]]$CN[ref_genes.list[["summary"]]$CN$MeanCopyNumber <= cn_bottom | ref_genes.list[["summary"]]$CN$MeanCopyNumber >= cn_top, ]$Gene)
+
   ##### Remove NAs
-  if ( length(ref_genes.list[["summary"]]$CN) > 0 ) {
-    ref_genes.list[["summary"]]$CN <- ref_genes.list[["summary"]]$CN[ !(is.na(ref_genes.list[["summary"]]$CN)) ]
+  if (length(ref_genes.list[["summary"]]$CN) > 0) {
+    ref_genes.list[["summary"]]$CN <- ref_genes.list[["summary"]]$CN[!(is.na(ref_genes.list[["summary"]]$CN))]
   } else {
     ref_genes.list[["summary"]]$CN <- NULL
   }
@@ -776,53 +758,53 @@ if ( runPurpleChunk ) {
 # Immune reponse markers
 ref_genes.list[["summary"]]$Immune <- unique(ref_genes.list[["genes_immune"]]$immune_markers$SYMBOL)
 
-if ( params$immunogram ) {
+if (params$immunogram) {
   ref_genes.list[["summary"]]$Immune <- unique(c(ref_genes.list[["summary"]]$Immune, ref_genes.list[["genes_immune"]]$immunogram$SYMBOL))
-  
+
   ##### Remove NAs
-  ref_genes.list[["summary"]]$Immune <- ref_genes.list[["summary"]]$Immune[ !(is.na(ref_genes.list[["summary"]]$Immune)) ]
+  ref_genes.list[["summary"]]$Immune <- ref_genes.list[["summary"]]$Immune[!(is.na(ref_genes.list[["summary"]]$Immune))]
 }
 
 # HRD (homologous recombination deficiency) genes
 ref_genes.list[["summary"]]$HRD <- unique(ref_genes.list[["genes_hrd"]]$SYMBOL)
 
 ##### Remove NAs
-ref_genes.list[["summary"]]$HRD <- ref_genes.list[["summary"]]$HRD[ !(is.na(ref_genes.list[["summary"]]$HRD)) ]
-  
+ref_genes.list[["summary"]]$HRD <- ref_genes.list[["summary"]]$HRD[!(is.na(ref_genes.list[["summary"]]$HRD))]
+
 # Cancer genes derived from UMCCR Cancer Gene list (https://github.com/vladsaveliev/NGS_Utils/blob/master/ngs_utils/reference_data/key_genes/umccr_cancer_genes.2019-03-20.tsv) and from OncoKB portal (http://oncokb.org/#/cancerGenes)
 ref_genes.list[["summary"]]$Cancer <- rownames(ref_genes.list[["genes_cancer"]])
 
 ##### Remove NAs
-ref_genes.list[["summary"]]$Cancer <- ref_genes.list[["summary"]]$Cancer[ !(is.na(ref_genes.list[["summary"]]$Cancer)) ]
+ref_genes.list[["summary"]]$Cancer <- ref_genes.list[["summary"]]$Cancer[!(is.na(ref_genes.list[["summary"]]$Cancer))]
 
 ##### Record all genes of interest
-genes2keep <- unique( unlist(ref_genes.list[["summary"]]) )
+genes2keep <- unique(unlist(ref_genes.list[["summary"]]))
 ```
 
 ```{r goi_annotation, comment = NA, message=FALSE, warning=FALSE}
 ##### Get gene symbols for the genes of interest. These genes will not be filtered out due to low/insufficient expression
 ##### Get genes annotation and genomic locations
 edb <- eval(parse(text = paste0("EnsDb.Hsapiens.v", params$ensembl_version)))
-  
+
 ##### Get keytypes for gene SYMBOL
-keys <- keys(edb, keytype="GENEID")
-  
+keys <- keys(edb, keytype = "GENEID")
+
 ##### Get genes genomic coordiantes
-gene_info <- ensembldb::select(edb, keys=keys, columns=c("GENEID", "GENENAME"), keytype="GENEID")
+gene_info <- ensembldb::select(edb, keys = keys, columns = c("GENEID", "GENENAME"), keytype = "GENEID")
 names(gene_info) <- gsub("GENEID", "ENSEMBL", names(gene_info))
 names(gene_info) <- gsub("GENENAME", "SYMBOL", names(gene_info))
-  
+
 ##### Limit genes annotation to the gene of interest
-genes2keep <- gene_info[ gene_info$SYMBOL %in% genes2keep,  ]
-  
+genes2keep <- gene_info[gene_info$SYMBOL %in% genes2keep, ]
+
 ##### Remove rows with duplicated ENSEMBL IDs
-genes2keep = genes2keep[!duplicated(genes2keep$ENSEMBL),]
+genes2keep <- genes2keep[!duplicated(genes2keep$ENSEMBL), ]
 rownames(genes2keep) <- genes2keep$ENSEMBL
 
 ##### Remove rows with duplicated gene symbols (Y_RNAs, SNORs, LINC0s etc). Preferably select ENSEMBL ID that is used in the count data
-genes2keep.combined_data <- genes2keep[ genes2keep$ENSEMBL %in% rownames(ref_dataset.list[[dataset]]$combined_data), ]
-genes2keep <- genes2keep[ genes2keep$SYMBOL %!in% genes2keep.combined_data$SYMBOL, ]
-genes2keep <-  genes2keep[!duplicated(genes2keep$SYMBOL),]
+genes2keep.combined_data <- genes2keep[genes2keep$ENSEMBL %in% rownames(ref_dataset.list[[dataset]]$combined_data), ]
+genes2keep <- genes2keep[genes2keep$SYMBOL %!in% genes2keep.combined_data$SYMBOL, ]
+genes2keep <- genes2keep[!duplicated(genes2keep$SYMBOL), ]
 genes2keep <- rbind(genes2keep.combined_data, genes2keep)
 
 ##### Add column to store info about filtered genes
@@ -838,8 +820,8 @@ suppressMessages(library(plotly))
 
 data <- ref_dataset.list[[dataset]][["combined_data"]]
 target <- ref_dataset.list[[dataset]][["sample_annot"]]
-target$Target[ target$Target==sample_name ] <- "Patient"
-rownames(target)[ rownames(target)==sample_name ] <- "Patient"
+target$Target[target$Target == sample_name] <- "Patient"
+rownames(target)[rownames(target) == sample_name] <- "Patient"
 
 ##### Change the datasets levels order
 target$Target <- factor(target$Target, levels = unique(target$Target))
@@ -848,32 +830,32 @@ target$Target <- factor(target$Target, levels = unique(target$Target))
 targets.colour <- getColours(target$Target)
 
 ##### Prepare data frame
-data.df <- data.frame(rownames(target), as.numeric(colSums(data)*1e-6), target$Target)
+data.df <- data.frame(rownames(target), as.numeric(colSums(data) * 1e-6), target$Target)
 colnames(data.df) <- c("Sample", "Library_size", "Target")
 
 ##### The default order will be alphabetized unless specified as below
 data.df$Sample <- factor(data.df$Sample, levels = data.df[["Sample"]])
 
-library_size <- plot_ly(data.df, x = ~Sample, y = ~Library_size, color = ~Target, colors = targets.colour[[1]], type = 'bar', width = 800, height = 400) %>%
-  layout(title = "", xaxis = list( tickfont = list(size = 10), title = "", showticklabels = FALSE), yaxis = list(title = "Library size (millions)"), margin = list(l=50, r=50, b=50, t=50, pad=4), autosize = F, showlegend=TRUE, legend = list(orientation = 'h', y = max(data.df$Library_size), bgcolor = "white"))
+library_size <- plot_ly(data.df, x = ~Sample, y = ~Library_size, color = ~Target, colors = targets.colour[[1]], type = "bar", width = 800, height = 400) %>%
+  layout(title = "", xaxis = list(tickfont = list(size = 10), title = "", showticklabels = FALSE), yaxis = list(title = "Library size (millions)"), margin = list(l = 50, r = 50, b = 50, t = 50, pad = 4), autosize = F, showlegend = TRUE, legend = list(orientation = "h", y = max(data.df$Library_size), bgcolor = "white"))
 
 ##### Create directory for input data plots
 PlotsDir <- paste(results_dir, "InputDataPlots", sep = "/")
-if ( !file.exists(PlotsDir) ) {
-  dir.create(PlotsDir, recursive=TRUE)
+if (!file.exists(PlotsDir)) {
+  dir.create(PlotsDir, recursive = TRUE)
 }
 
 ##### Save interactive plot as html file
 saveWidgetFix(library_size, file = paste(PlotsDir, "library_size.html", sep = "/"))
-  
+
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 ```
 
 ```{r data_transformation_filtering, comment = NA, message=FALSE, warning=FALSE}
 ##### Filtering to remove low expressed genes. For differential expression and related analyses, gene expression is rarely considered at the level of raw counts since libraries sequenced at a greater depth will result in higher counts. Rather, it is common practice to transform raw counts onto a scale that accounts for such library size differences. Genes with very low counts across all libraries provide little evidence for differential expression. In the biological point of view, a gene must be expressed at some minimal level before it is likely to be translated into a protein or to be biologically important. In addition, the pronounced discretenes of these counts interferes with some of the statistical approximations that are used later in the pipeline. These genes should be filtered out prior to further analysis. Users should filter with CPM rather than filtering on the counts directly, as the latter does not account for differences in library sizes between samples. For instance for the CPM-transformed data we keep only genes that have CPM of 1
 
-##### Transformation to CPM or TPM scale (see these blogs for details https://www.rna-seqblog.com/rpkm-fpkm-and-tpm-clearly-explained/ and https://haroldpimentel.wordpress.com/2014/05/08/what-the-fpkm-a-review-rna-seq-expression-units/ ).  CPM = Counts Per Million,  TPM = Transcripts Per Kilobase Million. 
+##### Transformation to CPM or TPM scale (see these blogs for details https://www.rna-seqblog.com/rpkm-fpkm-and-tpm-clearly-explained/ and https://haroldpimentel.wordpress.com/2014/05/08/what-the-fpkm-a-review-rna-seq-expression-units/ ).  CPM = Counts Per Million,  TPM = Transcripts Per Kilobase Million.
 
 ##### For counts data processing consider the investigated sample and internal reference cohort as one group  (regardless of the investigated patient tissie origin), and TCGA data (of any cancer type) as another group. This is to facilitate batch-effects (related with technical aspects) correction process
 target_mod <- ref_dataset.list[[dataset]][["sample_annot"]]
@@ -885,114 +867,110 @@ y <- vector("list", length(targets_mod.list))
 names(y) <- targets_mod.list
 
 ##### Keep info about samples with the lowest and greates counts for defined CPM threshold
-cpm.min <- round(min(as.numeric(colSums(ref_dataset.list[[dataset]][["combined_data"]])*1e-6)), digits=0)
-cpm.max <- round(max(as.numeric(colSums(ref_dataset.list[[dataset]][["combined_data"]])*1e-6)), digits=0)
+cpm.min <- round(min(as.numeric(colSums(ref_dataset.list[[dataset]][["combined_data"]]) * 1e-6)), digits = 0)
+cpm.max <- round(max(as.numeric(colSums(ref_dataset.list[[dataset]][["combined_data"]]) * 1e-6)), digits = 0)
 
 #### For each group...
-for ( group in targets_mod.list ) {
-    target <- target_mod[ target_mod$Dataset==group, ]
-    data <- ref_dataset.list[[dataset]][["combined_data"]]
-    data <- data[ , target_mod$Dataset==group]
-    
+for (group in targets_mod.list) {
+  target <- target_mod[target_mod$Dataset == group, ]
+  data <- ref_dataset.list[[dataset]][["combined_data"]]
+  data <- data[, target_mod$Dataset == group]
+
   ##### CPM transformation and filtering
-  if ( params$filter && params$transform == "CPM" ) {
-    
+  if (params$filter && params$transform == "CPM") {
     ##### Create EdgeR DGEList object
-    y[[group]] <- edgeR::DGEList(counts=data,  group=target$Dataset)
-    
+    y[[group]] <- edgeR::DGEList(counts = data, group = target$Dataset)
+
     ##### Keep genes with CPM of at least 1 in more than 10% of samples
     filter.threshold <- 1
-    keep <- rowSums(edgeR::cpm(y[[group]])>filter.threshold) >= ncol(data)/10
-    
+    keep <- rowSums(edgeR::cpm(y[[group]]) > filter.threshold) >= ncol(data) / 10
+
     ##### Note which genes of interest are not expressed
-    genes2keep$EXP[ rownames(genes2keep) %!in% names(keep) ] <- FALSE
-    
+    genes2keep$EXP[rownames(genes2keep) %!in% names(keep)] <- FALSE
+
     ##### Keep the genes of interest too
-    keep[ names(keep) %in% rownames(genes2keep) ] <- TRUE
-    y[[group]]$filtered <- y[[group]][keep, , keep.lib.sizes=FALSE]
-    
+    keep[names(keep) %in% rownames(genes2keep)] <- TRUE
+    y[[group]]$filtered <- y[[group]][keep, , keep.lib.sizes = FALSE]
+
     ##### Transform the raw-scale to CPM. Add small offset to each observation to avoid taking log of zero
-    y[[group]]$transformed <- edgeR::cpm(y[[group]], normalized.lib.sizes=FALSE, log=params$log, prior.count=0.25)
-    y[[group]]$filtered.transformed <- edgeR::cpm(y[[group]]$filtered, normalized.lib.sizes=FALSE, log=params$log, prior.count=0.25)
-  
-  ##### CPM transformation without filtering
-  } else if ( !params$filter && params$transform == "CPM" ) {
+    y[[group]]$transformed <- edgeR::cpm(y[[group]], normalized.lib.sizes = FALSE, log = params$log, prior.count = 0.25)
+    y[[group]]$filtered.transformed <- edgeR::cpm(y[[group]]$filtered, normalized.lib.sizes = FALSE, log = params$log, prior.count = 0.25)
+
+    ##### CPM transformation without filtering
+  } else if (!params$filter && params$transform == "CPM") {
     ##### Create EdgeR DGEList object
-    y[[group]] <- edgeR::DGEList(counts=data,  group=target$Dataset)
-    
+    y[[group]] <- edgeR::DGEList(counts = data, group = target$Dataset)
+
     ##### Transform the raw-scale to CPM. Add small offset to each observation to avoid taking log of zero
-    y[[group]]$transformed <- edgeR::cpm(y[[group]], normalized.lib.sizes=FALSE, log=params$log, prior.count=0.25)
-    
-  ##### TPM data transformation. We can convert RPKM to TPM in two different ways: from pre-calculated RPKM, by diving by the sum of RPKM values, or directly from the normalized counts. Here we calculate TPM starting from RPKM values computed using edgeR's rpkm function ( from http://luisvalesilva.com/datasimple/rna-seq_units.html )
-  ##### TPM transformation with filtering
-  } else if ( params$filter && params$transform == "TPM" ) {
-    
+    y[[group]]$transformed <- edgeR::cpm(y[[group]], normalized.lib.sizes = FALSE, log = params$log, prior.count = 0.25)
+
+    ##### TPM data transformation. We can convert RPKM to TPM in two different ways: from pre-calculated RPKM, by diving by the sum of RPKM values, or directly from the normalized counts. Here we calculate TPM starting from RPKM values computed using edgeR's rpkm function ( from http://luisvalesilva.com/datasimple/rna-seq_units.html )
+    ##### TPM transformation with filtering
+  } else if (params$filter && params$transform == "TPM") {
     ##### Get genes lengths
     edb <- eval(parse(text = paste0("EnsDb.Hsapiens.v", params$ensembl_version)))
     gene.length <- lengthOf(edb, filter = GeneIdFilter(rownames(data)))
-    
+
     ##### Check for which genes the lenght info is not available and remove them from the data
-    genes.no_length <- rownames(data)[ rownames(data) %!in% names(gene.length)]
-    data <- data[ rownames(data) %!in% genes.no_length, ]
-    
+    genes.no_length <- rownames(data)[rownames(data) %!in% names(gene.length)]
+    data <- data[rownames(data) %!in% genes.no_length, ]
+
     ##### Create EdgeR DGEList object
-    y[[group]] <- edgeR::DGEList(counts=data,  group=target$Dataset)
-    
+    y[[group]] <- edgeR::DGEList(counts = data, group = target$Dataset)
+
     ##### Convert data into RPKM
-    y[[group]]$transformed <- edgeR::rpkm(y[[group]], gene.length = gene.length, normalized.lib.sizes=FALSE, log=FALSE)
-    
+    y[[group]]$transformed <- edgeR::rpkm(y[[group]], gene.length = gene.length, normalized.lib.sizes = FALSE, log = FALSE)
+
     ##### ... and then to TPM scale. Add small offset to each observation to avoid taking log of zero
-    if ( params$log ) {
-      y[[group]]$transformed <- log2(tpm_from_rpkm(y[[group]]$transformed+0.25))
-      
+    if (params$log) {
+      y[[group]]$transformed <- log2(tpm_from_rpkm(y[[group]]$transformed + 0.25))
+
       ##### Keep genes with TPM of at least 1 in more than 10% of samples
-      filter.threshold <- 1+0.25
-      keep <- rowSums(y[[group]]$transformed > filter.threshold) >= ncol(y[[group]]$transformed)/10
-      
+      filter.threshold <- 1 + 0.25
+      keep <- rowSums(y[[group]]$transformed > filter.threshold) >= ncol(y[[group]]$transformed) / 10
+
       ##### Note which genes of interest are not expressed
-      genes2keep$EXP[ rownames(genes2keep) %!in% names(keep) ] <- FALSE
-    
+      genes2keep$EXP[rownames(genes2keep) %!in% names(keep)] <- FALSE
+
       ##### Keep the genes of interest too
-      keep[ names(keep) %in% rownames(genes2keep) ] <- TRUE
+      keep[names(keep) %in% rownames(genes2keep)] <- TRUE
       y[[group]]$filtered <- y[[group]]$counts[keep, ]
       y[[group]]$filtered.transformed <- y[[group]]$transformed[keep, ]
-   
     } else {
       y[[group]]$transformed <- tpm_from_rpkm(y[[group]]$transformed)
-      
+
       ##### Keep genes with TPM of at least 1 in more than 10% of samples
       filter.threshold <- 1
-      keep <- rowSums(y[[group]]$transformed > filter.threshold) >= ncol(y[[group]]$transformed)/10
-      
+      keep <- rowSums(y[[group]]$transformed > filter.threshold) >= ncol(y[[group]]$transformed) / 10
+
       ##### Note which genes of interest are not expressed
-      genes2keep$EXP[ rownames(genes2keep) %!in% names(keep) ] <- FALSE
-    
+      genes2keep$EXP[rownames(genes2keep) %!in% names(keep)] <- FALSE
+
       ##### Keep the genes of interest too
-      keep[ names(keep) %in% rownames(genes2keep) ] <- TRUE
+      keep[names(keep) %in% rownames(genes2keep)] <- TRUE
       y[[group]]$filtered <- y[[group]]$counts[keep, ]
       y[[group]]$filtered.transformed <- y[[group]]$transformed[keep, ]
     }
-  
-  ##### TPM transformation without filtering
-  } else if ( !params$filter && params$transform == "TPM" ) {
-    
+
+    ##### TPM transformation without filtering
+  } else if (!params$filter && params$transform == "TPM") {
     ##### Get genes lengths
     edb <- eval(parse(text = paste0("EnsDb.Hsapiens.v", params$ensembl_version)))
     gene.length <- lengthOf(edb, filter = GeneIdFilter(rownames(data)))
-    
+
     ##### Check for which genes the lenght info is not available and remove them from the data
-    genes.no_length <- rownames(data)[ rownames(data) %!in% names(gene.length)]
-    data <- data[ rownames(data) %!in% genes.no_length, ]
-    
+    genes.no_length <- rownames(data)[rownames(data) %!in% names(gene.length)]
+    data <- data[rownames(data) %!in% genes.no_length, ]
+
     ##### Create EdgeR DGEList object
-    y[[group]] <- edgeR::DGEList(counts=data,  group=target$Dataset)
-    
+    y[[group]] <- edgeR::DGEList(counts = data, group = target$Dataset)
+
     ##### Convert data into RPKM
-    y[[group]]$transformed <- edgeR::rpkm(y[[group]], gene.length = gene.length, normalized.lib.sizes=FALSE, log=FALSE)
-    
+    y[[group]]$transformed <- edgeR::rpkm(y[[group]], gene.length = gene.length, normalized.lib.sizes = FALSE, log = FALSE)
+
     ##### ... and then to TPM scale. Add small offset to each observation to avoid taking log of zero
-    if ( params$log ) {
-      y[[group]]$transformed <- log2(tpm_from_rpkm(y[[group]]$transformed+0.25))
+    if (params$log) {
+      y[[group]]$transformed <- log2(tpm_from_rpkm(y[[group]]$transformed + 0.25))
     } else {
       y[[group]]$transformed <- tpm_from_rpkm(y[[group]]$transformed)
     }
@@ -1003,15 +981,14 @@ for ( group in targets_mod.list ) {
 y[["comb"]]$transformed <- cbind(y[[targets_mod.list[1]]]$transformed, y[[targets_mod.list[2]]]$transformed)
 y[["comb"]]$samples <- rbind(y[[targets_mod.list[1]]]$samples, y[[targets_mod.list[2]]]$samples)
 
-if ( params$filter ) {
-  
+if (params$filter) {
   ##### Keep only genes present in all sets
   genes_mod <- intersect(rownames(y[[targets_mod.list[1]]]$filtered), rownames(y[[targets_mod.list[2]]]$filtered))
-  y[[targets_mod.list[1]]]$filtered <- y[[targets_mod.list[1]]]$filtered[ rownames(y[[targets_mod.list[1]]]$filtered) %in% genes_mod, ]
-  y[[targets_mod.list[2]]]$filtered <- y[[targets_mod.list[2]]]$filtered[ rownames(y[[targets_mod.list[2]]]$filtered) %in% genes_mod, ]
-  y[[targets_mod.list[1]]]$filtered.transformed <- y[[targets_mod.list[1]]]$filtered.transformed[ rownames(y[[targets_mod.list[1]]]$filtered.transformed) %in% genes_mod, ]
-  y[[targets_mod.list[2]]]$filtered.transformed <- y[[targets_mod.list[2]]]$filtered.transformed[ rownames(y[[targets_mod.list[2]]]$filtered.transformed) %in% genes_mod, ]
- 
+  y[[targets_mod.list[1]]]$filtered <- y[[targets_mod.list[1]]]$filtered[rownames(y[[targets_mod.list[1]]]$filtered) %in% genes_mod, ]
+  y[[targets_mod.list[2]]]$filtered <- y[[targets_mod.list[2]]]$filtered[rownames(y[[targets_mod.list[2]]]$filtered) %in% genes_mod, ]
+  y[[targets_mod.list[1]]]$filtered.transformed <- y[[targets_mod.list[1]]]$filtered.transformed[rownames(y[[targets_mod.list[1]]]$filtered.transformed) %in% genes_mod, ]
+  y[[targets_mod.list[2]]]$filtered.transformed <- y[[targets_mod.list[2]]]$filtered.transformed[rownames(y[[targets_mod.list[2]]]$filtered.transformed) %in% genes_mod, ]
+
   y[["comb"]]$filtered <- cbind(y[[targets_mod.list[1]]]$filtered, y[[targets_mod.list[2]]]$filtered)
   y[["comb"]]$filtered.transformed <- cbind(y[[targets_mod.list[1]]]$filtered.transformed, y[[targets_mod.list[2]]]$filtered.transformed)
 }
@@ -1024,138 +1001,136 @@ rm(target, target_mod, genes_mod, keep)
 ##### Assign colours to targets and datasets
 target <- ref_dataset.list[[dataset]][["sample_annot"]]
 targets.colour <- getColours(target$Target)
-  
+
 ##### Collect the most extreme density values for set the x-axis and y-axis boundaries
-den.x <- density(y[["comb"]]$transformed[,1])$x
-den.y <- density(y[["comb"]]$transformed[,1])$y
-  
+den.x <- density(y[["comb"]]$transformed[, 1])$x
+den.y <- density(y[["comb"]]$transformed[, 1])$y
+
 for (i in 2:ncol(y[["comb"]]$transformed)) {
-  den <- density(y[["comb"]]$transformed[,i])
+  den <- density(y[["comb"]]$transformed[, i])
   den.x <- sort(c(den.x, den$x))
   den.y <- sort(c(den.y, den$y))
 }
 
 ##### Plot read counts against transformed data
-if ( params$filter ) {
+if (params$filter) {
   suppressMessages(library(plotly))
-  
+
   ##### Organise the data into data frame
-  if ( params$log ) {
-    data.df <- as.data.frame(cbind( exp(y[["comb"]]$transformed[,ncol(y[["comb"]]$transformed)]), ref_dataset.list[[dataset]][["combined_data"]][,ncol(ref_dataset.list[[dataset]][["combined_data"]])]))
+  if (params$log) {
+    data.df <- as.data.frame(cbind(exp(y[["comb"]]$transformed[, ncol(y[["comb"]]$transformed)]), ref_dataset.list[[dataset]][["combined_data"]][, ncol(ref_dataset.list[[dataset]][["combined_data"]])]))
     names(data.df) <- c("Transformed", "Counts")
     data.df$Transformed <- log(data.df$Transformed)
-    
   } else {
-     data.df <- as.data.frame(cbind( y[["comb"]]$transformed[,ncol(y[["comb"]]$transformed)], ref_dataset.list[[dataset]][["combined_data"]][,ncol(ref_dataset.list[[dataset]][["combined_data"]])]))
+    data.df <- as.data.frame(cbind(y[["comb"]]$transformed[, ncol(y[["comb"]]$transformed)], ref_dataset.list[[dataset]][["combined_data"]][, ncol(ref_dataset.list[[dataset]][["combined_data"]])]))
     names(data.df) <- c("Transformed", "Counts")
   }
-  
+
   ##### Keep only genes with read counts below the 99th percentile
-  data.df <- data.df[ data.df$Counts < quantile(data.df$Counts, 0.99), ]
-  
+  data.df <- data.df[data.df$Counts < quantile(data.df$Counts, 0.99), ]
+
   ##### Keep only every 25th genes to reduce the size of the plot
-  data.df <- data.df[ seq(1,nrow(data.df), by=25), ]
-  
+  data.df <- data.df[seq(1, nrow(data.df), by = 25), ]
+
   ##### Generate plot for filtered data
-  counts_vs_transformed <- plot_ly( data.df, x = ~Transformed, y = ~Counts, width = 800, height = 300, color = I('black'), marker = list(size = 5), type="scatter", mode = "markers", name = paste0(params$transform, " / Counts (Patient)") ) %>% 
-    add_trace(x = c(filter.threshold, filter.threshold), y= c(0, max(data.df$Counts)), mode = "lines", color = I("red"), name = "Filtering threshold") %>%
-    
-    layout(title = "", xaxis = list(title = paste0(params$transform, "s")), yaxis = list(title = "Counts"), showlegend=TRUE)
-  
+  counts_vs_transformed <- plot_ly(data.df, x = ~Transformed, y = ~Counts, width = 800, height = 300, color = I("black"), marker = list(size = 5), type = "scatter", mode = "markers", name = paste0(params$transform, " / Counts (Patient)")) %>%
+    add_trace(x = c(filter.threshold, filter.threshold), y = c(0, max(data.df$Counts)), mode = "lines", color = I("red"), name = "Filtering threshold") %>%
+    layout(title = "", xaxis = list(title = paste0(params$transform, "s")), yaxis = list(title = "Counts"), showlegend = TRUE)
+
   ##### Save interactive plot as html file
   saveWidgetFix(counts_vs_transformed, file = paste(PlotsDir, "counts_vs_transformed.html", sep = "/"))
 
   ##### Detach plotly package. Otherwise it clashes with other graphics devices
-  detach("package:plotly", unload=FALSE)
-  
-  if ( !is.null(add_cancer_group) ) {
+  detach("package:plotly", unload = FALSE)
+
+  if (!is.null(add_cancer_group)) {
     legend <- c(ext_cancer_group, add_cancer_group, int_cancer_group, "Patient")
   } else {
     legend <- c(ext_cancer_group, int_cancer_group, "Patient")
   }
-  
+
   ##### Before filtering
-  par(mfrow=c(1,2))
-  plot(density(y[["comb"]]$transformed[,1]), lwd=2, xlim=c(den.x[1],max(data.df$Transformed)), ylim=c(den.y[1],den.y[length(den.y)]), las=2, main="", xlab="", col=targets.colour[[2]][1])
-  title(main="Transformed data (unfiltered)", xlab=params$transform)
-  abline(v=0, lty=3)
-  
-  for (i in 2:ncol(y[["comb"]]$transformed)){
-    den <- density(y[["comb"]]$transformed[,i])
-    lines(den$x, den$y, lwd=2, col=targets.colour[[2]][i])
+  par(mfrow = c(1, 2))
+  plot(density(y[["comb"]]$transformed[, 1]), lwd = 2, xlim = c(den.x[1], max(data.df$Transformed)), ylim = c(den.y[1], den.y[length(den.y)]), las = 2, main = "", xlab = "", col = targets.colour[[2]][1])
+  title(main = "Transformed data (unfiltered)", xlab = params$transform)
+  abline(v = 0, lty = 3)
+
+  for (i in 2:ncol(y[["comb"]]$transformed)) {
+    den <- density(y[["comb"]]$transformed[, i])
+    lines(den$x, den$y, lwd = 2, col = targets.colour[[2]][i])
   }
-  legend("topright", legend=legend, fill=targets.colour[[1]], bty="n", bg = "transparent")
-  
+  legend("topright", legend = legend, fill = targets.colour[[1]], bty = "n", bg = "transparent")
+
   data_transformation_nonfiltered <- recordPlot()
-  
+
   ##### After filtering
-  plot(density(y[["comb"]]$filtered.transformed[,1]), lwd=2, xlim=c(den.x[1],max(data.df$Transformed)), ylim=c(den.y[1],den.y[length(den.y)]), las=2, main="", xlab="", col=targets.colour[[2]][1])
-  title(main="Transformed and filtered data", xlab=params$transform)
-  abline(v=0, lty=3)
-  
-  for (i in 2:ncol(y[["comb"]]$filtered.transformed)){
-    den <- density(y[["comb"]]$filtered.transformed[,i])
-    lines(den$x, den$y, lwd=2, col=targets.colour[[2]][i])
+  plot(density(y[["comb"]]$filtered.transformed[, 1]), lwd = 2, xlim = c(den.x[1], max(data.df$Transformed)), ylim = c(den.y[1], den.y[length(den.y)]), las = 2, main = "", xlab = "", col = targets.colour[[2]][1])
+  title(main = "Transformed and filtered data", xlab = params$transform)
+  abline(v = 0, lty = 3)
+
+  for (i in 2:ncol(y[["comb"]]$filtered.transformed)) {
+    den <- density(y[["comb"]]$filtered.transformed[, i])
+    lines(den$x, den$y, lwd = 2, col = targets.colour[[2]][i])
   }
-  legend("topright", legend=legend, fill=targets.colour[[1]], bty="n", bg = "transparent")
-  
+  legend("topright", legend = legend, fill = targets.colour[[1]], bty = "n", bg = "transparent")
+
   data_transformation_filtered <- recordPlot()
-  
+
   ##### Save the plot as png file
-  png(paste0(PlotsDir, "/filtering.png"), width=900, height=400, pointsize = 14)
-  par(mfrow=c(1,2))
-  
+  png(paste0(PlotsDir, "/filtering.png"), width = 900, height = 400, pointsize = 14)
+  par(mfrow = c(1, 2))
+
   ##### Before filtering
-  plot(density(y[["comb"]]$transformed[,1]), lwd=2, xlim=c(den.x[1],den.x[length(den.x)]), ylim=c(den.y[1],den.y[length(den.y)]), las=2, main="", xlab="", col=targets.colour[[2]][1])
-  title(main="Transformed data (unfiltered)", xlab=params$transform)
-  abline(v=0, lty=3)
-  
-  for (i in 2:ncol(y[["comb"]]$transformed)){
-    den <- density(y[["comb"]]$transformed[,i])
-    lines(den$x, den$y, lwd=2, col=targets.colour[[2]][i])
+  plot(density(y[["comb"]]$transformed[, 1]), lwd = 2, xlim = c(den.x[1], den.x[length(den.x)]), ylim = c(den.y[1], den.y[length(den.y)]), las = 2, main = "", xlab = "", col = targets.colour[[2]][1])
+  title(main = "Transformed data (unfiltered)", xlab = params$transform)
+  abline(v = 0, lty = 3)
+
+  for (i in 2:ncol(y[["comb"]]$transformed)) {
+    den <- density(y[["comb"]]$transformed[, i])
+    lines(den$x, den$y, lwd = 2, col = targets.colour[[2]][i])
   }
-  legend("topright", legend=legend, fill=targets.colour[[1]], cex = 0.7, bty="n", bg = "transparent")
-  
+  legend("topright", legend = legend, fill = targets.colour[[1]], cex = 0.7, bty = "n", bg = "transparent")
+
   ##### After filtering
-  plot(density(y[["comb"]]$filtered.transformed[,1]), lwd=2, xlim=c(den.x[1],den.x[length(den.x)]), ylim=c(den.y[1],den.y[length(den.y)]), las=2, main="", xlab="", col=targets.colour[[2]][1])
-  title(main="Transformed and filtered data", xlab=params$transform)
-  abline(v=0, lty=3)
-  
-  for (i in 2:ncol(y[["comb"]]$filtered.transformed)){
-    den <- density(y[["comb"]]$filtered.transformed[,i])
-    lines(den$x, den$y, lwd=2, col=targets.colour[[2]][i])
+  plot(density(y[["comb"]]$filtered.transformed[, 1]), lwd = 2, xlim = c(den.x[1], den.x[length(den.x)]), ylim = c(den.y[1], den.y[length(den.y)]), las = 2, main = "", xlab = "", col = targets.colour[[2]][1])
+  title(main = "Transformed and filtered data", xlab = params$transform)
+  abline(v = 0, lty = 3)
+
+  for (i in 2:ncol(y[["comb"]]$filtered.transformed)) {
+    den <- density(y[["comb"]]$filtered.transformed[, i])
+    lines(den$x, den$y, lwd = 2, col = targets.colour[[2]][i])
   }
-  legend("topright", legend=legend, fill=targets.colour[[1]], cex = 0.7, bty="n", bg = "transparent")
+  legend("topright", legend = legend, fill = targets.colour[[1]], cex = 0.7, bty = "n", bg = "transparent")
   invisible(dev.off())
-  
-##### Without filtering
+
+  ##### Without filtering
 } else {
-  plot(density(y[["comb"]]$transformed[,1]), lwd=2, xlim=c(den.x[1],den.x[length(den.x)]), ylim=c(den.y[1],den.y[length(den.y)]), las=2, main="", xlab="", col=targets.colour[[2]][1])
-  title(main="Transformed data (unfiltered)", xlab=params$transform)
-  abline(v=0, lty=3)
-  
-  for (i in 2:ncol(y[["comb"]]$transformed)){
-    den <- density(y[["comb"]]$transformed[,i])
-    lines(den$x, den$y, lwd=2, col=targets.colour[[2]][i])
+  plot(density(y[["comb"]]$transformed[, 1]), lwd = 2, xlim = c(den.x[1], den.x[length(den.x)]), ylim = c(den.y[1], den.y[length(den.y)]), las = 2, main = "", xlab = "", col = targets.colour[[2]][1])
+  title(main = "Transformed data (unfiltered)", xlab = params$transform)
+  abline(v = 0, lty = 3)
+
+  for (i in 2:ncol(y[["comb"]]$transformed)) {
+    den <- density(y[["comb"]]$transformed[, i])
+    lines(den$x, den$y, lwd = 2, col = targets.colour[[2]][i])
   }
-  legend("topright", legend=legend, fill=targets.colour[[1]], bty="n", bg = "transparent")
-  
+  legend("topright", legend = legend, fill = targets.colour[[1]], bty = "n", bg = "transparent")
+
   data_transformation_nonfiltered <- recordPlot()
-  
+
   #### Clear plots to free up some memory
-  if(!is.null(dev.list())) invisible(dev.off())
-  
+  if (!is.null(dev.list())) invisible(dev.off())
+
   ##### Save the plot as png file
-  png(paste0(PlotsDir, "/filtering.png"), width=900, height=400, pointsize = 14)
-  plot(density(y[["comb"]]$transformed[,1]), lwd=2, xlim=c(den.x[1],den.x[length(den.x)]), ylim=c(den.y[1],den.y[length(den.y)]), las=2, main="", xlab="", col=targets.colour[[2]][1])
-  title(main="Transformed data (unfiltered)", xlab=params$transform)
-  abline(v=0, lty=3)
-  
-  for (i in 2:ncol(y[["comb"]]$transformed)){
-    den <- density(y[["comb"]]$transformed[,i])
-    lines(den$x, den$y, lwd=2, col=targets.colour[[2]][i])
+  png(paste0(PlotsDir, "/filtering.png"), width = 900, height = 400, pointsize = 14)
+  plot(density(y[["comb"]]$transformed[, 1]), lwd = 2, xlim = c(den.x[1], den.x[length(den.x)]), ylim = c(den.y[1], den.y[length(den.y)]), las = 2, main = "", xlab = "", col = targets.colour[[2]][1])
+  title(main = "Transformed data (unfiltered)", xlab = params$transform)
+  abline(v = 0, lty = 3)
+
+  for (i in 2:ncol(y[["comb"]]$transformed)) {
+    den <- density(y[["comb"]]$transformed[, i])
+    lines(den$x, den$y, lwd = 2, col = targets.colour[[2]][i])
   }
-  legend("topright", legend=legend, fill=targets.colour[[1]], cex = 0.7, bty="n", bg = "transparent")
+  legend("topright", legend = legend, fill = targets.colour[[1]], cex = 0.7, bty = "n", bg = "transparent")
   invisible(dev.off())
 }
 
@@ -1167,58 +1142,55 @@ rm(data, data.df, target, den.x, den.y)
 ##### During the sample preparation or sequencing process, external factors that are not of biological interest can affect the expression of individual samples. For example, samples processed in the first batch of an experiment can have higher expression overall when compared to samples processed in a second batch. It is assumed that all samples should have a similar range and distribution of expression values. Normalisation for sample-specific effects is required to ensure that the expression distributions of each sample are similar across the entire experiment.
 
 ##### TMM normalsation. Trimmed mean of M-values (https://www.ncbi.nlm.nih.gov/pubmed/20196867) (TMM) is performed using the calcNormFactors function in edgeR. The normalisation factors calculated here are used as a scaling factor for the library sizes. TMM is the recommended for most RNA-Seq data where the majority (more than half) of the genes are believed not differentially expressed between any pair of the samples. It adjusts for RNA composition effect, calculates scaling factors for the library sizes with calcNormFactors function using trimmed mean of M-values (TMM) between each pair of samples. Note, that the raw read counts are used to calculate the normalisation factors
-  
+
 #### For each group...
-for ( group in targets_mod.list ) {
-  if ( params$transform == "CPM" ) {
-    
+for (group in targets_mod.list) {
+  if (params$transform == "CPM") {
     ##### Calculate normalization factors and transformations from the raw-scale to CPM and normalisation using user-defined method
-    if ( params$filter ) {
+    if (params$filter) {
       y[[group]]$noNorm <- y[[group]]$filtered.transformed
       y[[group]]$filtered$samples["norm.factors"] <- edgeR::calcNormFactors(y[[group]]$filtered, method = params$norm)$samples["norm.factors"]
-      y[[group]]$norm <- edgeR::cpm(y[[group]]$filtered, normalized.lib.sizes=TRUE, log=params$log, prior.count=0.25)
-    
+      y[[group]]$norm <- edgeR::cpm(y[[group]]$filtered, normalized.lib.sizes = TRUE, log = params$log, prior.count = 0.25)
     } else {
       y[[group]]$noNorm <- y[[group]]$transformed
       y[[group]]$samples["norm.factors"] <- edgeR::calcNormFactors(y[[group]], method = params$norm)$samples["norm.factors"]
-      y[[group]]$norm <- edgeR::cpm(y[[group]], normalized.lib.sizes=TRUE, log=params$log, prior.count=0.25)
+      y[[group]]$norm <- edgeR::cpm(y[[group]], normalized.lib.sizes = TRUE, log = params$log, prior.count = 0.25)
     }
-    
-  ##### Quantile normalsation (from https://www.biostars.org/p/296992/ )
-  } else if ( params$transform == "TPM" ) {
-    
+
+    ##### Quantile normalsation (from https://www.biostars.org/p/296992/ )
+  } else if (params$transform == "TPM") {
     ##### Normalisation using quantile method
-    if ( params$filter ) {
+    if (params$filter) {
       y[[group]]$noNorm <- y[[group]]$filtered.transformed
-      y[[group]]$filtered.transformed <- data.matrix(y[[group]]$filtered.transformed) 
-      
-      if ( tolower(params$norm) != "none" ) {
-        y[[group]]$norm  <- normalize.quantiles(y[[group]]$filtered.transformed, copy = TRUE)
+      y[[group]]$filtered.transformed <- data.matrix(y[[group]]$filtered.transformed)
+
+      if (tolower(params$norm) != "none") {
+        y[[group]]$norm <- normalize.quantiles(y[[group]]$filtered.transformed, copy = TRUE)
         colnames(y[[group]]$norm) <- colnames(y[[group]]$filtered.transformed)
         rownames(y[[group]]$norm) <- rownames(y[[group]]$filtered.transformed)
       } else {
-        y[[group]]$norm  <- y[[group]]$filtered.transformed
+        y[[group]]$norm <- y[[group]]$filtered.transformed
       }
     } else {
       y[[group]]$noNorm <- y[[group]]$transformed
       y[[group]]$transformed <- data.matrix(y[[group]]$transformed)
-      
-      if ( tolower(params$norm) != "none" ) {
-        y[[group]]$norm  <- normalize.quantiles(y[[group]]$transformed, copy = TRUE)
+
+      if (tolower(params$norm) != "none") {
+        y[[group]]$norm <- normalize.quantiles(y[[group]]$transformed, copy = TRUE)
         colnames(y[[group]]$norm) <- colnames(y[[group]]$transformed)
         rownames(y[[group]]$norm) <- rownames(y[[group]]$transformed)
       } else {
-        y[[group]]$norm  <- y[[group]]$transformed
+        y[[group]]$norm <- y[[group]]$transformed
       }
     }
   }
-}  
+}
 
 ##### Combine DGEList objects created for each group
 y[["comb"]]$noNorm <- cbind(y[[targets_mod.list[1]]]$noNorm, y[[targets_mod.list[2]]]$noNorm)
 y[["comb"]]$norm <- cbind(y[[targets_mod.list[1]]]$norm, y[[targets_mod.list[2]]]$norm)
 
-if ( tolower(params$norm) != "none" ) {
+if (tolower(params$norm) != "none") {
   ref_dataset.list[[dataset]][["combined_data_processed"]] <- y[["comb"]]$norm
 } else {
   ref_dataset.list[[dataset]][["combined_data_processed"]] <- y[["comb"]]$noNorm
@@ -1230,35 +1202,35 @@ rm(targets_mod.list)
 
 ```{r data_normalisation_plot, comment = NA, message=FALSE, warning=FALSE, fig.width = 12, fig.height = 6, fig.show="hide"}
 ##### Plot expression distribution of samples for unnormalised and normalised data
-par(mfrow=c(2,1), mar=c(2, 5, 3, 2))
+par(mfrow = c(2, 1), mar = c(2, 5, 3, 2))
 
 ##### Unnormalised data
-boxplot(y[["comb"]]$noNorm, las=2, col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-title(main="Unnormalised data", ylab=params$transform)
-legend("topright", legend=legend, fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", box.col="transparent")
+boxplot(y[["comb"]]$noNorm, las = 2, col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+title(main = "Unnormalised data", ylab = params$transform)
+legend("topright", legend = legend, fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", box.col = "transparent")
 
 data_nonnormalised <- recordPlot()
 
 ##### Normalised data
-boxplot(y[["comb"]]$norm, las=2, col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-title(main=paste0("Normalised data (", params$norm, ")"), ylab=params$transform)
-legend("topright", legend=legend, fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", box.col="transparent")
+boxplot(y[["comb"]]$norm, las = 2, col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+title(main = paste0("Normalised data (", params$norm, ")"), ylab = params$transform)
+legend("topright", legend = legend, fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", box.col = "transparent")
 
 data_normalised <- recordPlot()
 
 ##### Save the plot as png file
-png(paste0(PlotsDir, "/normalisation.png"), width=900, height=700, pointsize = 14)
-par(mfrow=c(2,1), mar=c(2, 5, 3, 2))
-  
+png(paste0(PlotsDir, "/normalisation.png"), width = 900, height = 700, pointsize = 14)
+par(mfrow = c(2, 1), mar = c(2, 5, 3, 2))
+
 ##### Unnormalised data
-boxplot(y[["comb"]]$noNorm, las=2, col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-title(main="Unnormalised data", ylab=params$transform)
-legend("topright", legend=legend, fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", cex = 0.7, box.col="transparent")
-  
+boxplot(y[["comb"]]$noNorm, las = 2, col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+title(main = "Unnormalised data", ylab = params$transform)
+legend("topright", legend = legend, fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", cex = 0.7, box.col = "transparent")
+
 ##### Normalised data
-boxplot(y[["comb"]]$norm, las=2, col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-title(main=paste0("Normalised data (", params$norm, ")"), ylab=params$transform)
-legend("topright", legend=legend, fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", cex = 0.7, box.col="transparent")
+boxplot(y[["comb"]]$norm, las = 2, col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+title(main = paste0("Normalised data (", params$norm, ")"), ylab = params$transform)
+legend("topright", legend = legend, fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", cex = 0.7, box.col = "transparent")
 invisible(dev.off())
 
 ##### Clean the space
@@ -1270,7 +1242,7 @@ rm(den, y)
 batches <- as.character(ref_dataset.list[[dataset]][["sample_annot"]]$Dataset)
 
 ##### Change the sample dataset name to internal reference cohort
-batches[ match(sample_name, batches) ] <- int_cancer_group
+batches[match(sample_name, batches)] <- int_cancer_group
 
 ##### Perform batch-effect correctrion using limma
 ref_dataset.list[[dataset]][["batch_effect_corrected"]] <- limma::removeBatchEffect(ref_dataset.list[[dataset]][["combined_data_processed"]], batch = batches)
@@ -1281,91 +1253,89 @@ suppressMessages(library(plotly))
 
 ##### Perform principal component analysis (PCA) using combined-only data and batch-effect corrected data
 ##### Loop through combined datasets and perform PCA
-for ( dataset in names(ref_dataset.list) ) {
+for (dataset in names(ref_dataset.list)) {
   target <- ref_dataset.list[[dataset]][["sample_annot"]]
   target$Dataset <- gsub(sample_name, "Patient", target$Dataset)
   target$Target <- gsub(sample_name, "Patient", target$Target)
-  
-  if ( params$batch_rm ) {
+
+  if (params$batch_rm) {
     ref_dataset.list[[dataset]][["pca_combined_data_processed"]] <- pca(data = ref_dataset.list[[dataset]][["combined_data_processed"]], targets = target, title = "Before batch-effects correction", report_dir = results_dir, suffix = "_before_batch_rm")
-    
+
     ref_dataset.list[[dataset]][["pca_batch_effect_corrected"]] <- pca(data = ref_dataset.list[[dataset]][["batch_effect_corrected"]], targets = target, title = "After batch-effects correction", report_dir = results_dir, suffix = "_after_batch_rm")
-    
+
     ref_dataset.list[[dataset]][["data_to_report"]] <- ref_dataset.list[[dataset]][["batch_effect_corrected"]]
-    
   } else {
     ref_dataset.list[[dataset]][["pca_combined_data_processed"]] <- pca(data = ref_dataset.list[[dataset]][["combined_data_processed"]], targets = target, report_dir = results_dir)
-    
+
     ref_dataset.list[[dataset]][["data_to_report"]] <- ref_dataset.list[[dataset]][["combined_data_processed"]]
   }
 }
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 ```{r rle, comment = NA, message=FALSE, warning=FALSE, fig.width = 12, fig.height = 6, fig.show="hide"}
 ##### Generate relative log expression (RLE) plot using combined-only data and batch-effect corrected data
 ##### Loop through combined datasets and generate RLE plot
-for ( dataset in names(ref_dataset.list) ) {
+for (dataset in names(ref_dataset.list)) {
   target <- ref_dataset.list[[dataset]][["sample_annot"]]
   target$Dataset <- gsub(sample_name, "Patient", target$Dataset)
   target$Target <- gsub(sample_name, "Patient", target$Target)
-  
-  if ( params$batch_rm ) {
-    par(mfrow=c(2,1), mar=c(2, 5, 3, 2))
-    
-    ##### Before batch-effects correction
-    plotRLE(ref_dataset.list[[dataset]][["combined_data_processed"]], col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-    title(main="Before batch-effects correction", ylab="RLE")
-    legend("topright", legend=levels(factor(target$Target)), fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", box.col="transparent")
-    
-    ref_dataset.list[[dataset]][["rle_combined_data_processed"]] <- recordPlot()
-    
-    ##### After batch-effects correction
-    plotRLE(ref_dataset.list[[dataset]][["batch_effect_corrected"]], col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-    title(main="After batch-effects correction", ylab="RLE")
-    legend("topright", legend=levels(factor(target$Target)), fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", box.col="transparent")
-    
-    ref_dataset.list[[dataset]][["rle_batch_effect_corrected"]] <- recordPlot()
-    
-    
-    ##### Save the plot as png file
-    png(paste0(PlotsDir, "/rle.png"), width=900, height=700, pointsize = 14)
-    par(mfrow=c(2,1), mar=c(2, 5, 3, 2))
-  
-    ##### Before batch-effects correction
-    plotRLE(ref_dataset.list[[dataset]][["combined_data_processed"]], col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-    title(main="Before batch-effects correction", ylab="RLE")
-    legend("topright", legend=levels(factor(target$Target)), fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", box.col="transparent")
-  
-    ##### After batch-effects correction
-    plotRLE(ref_dataset.list[[dataset]][["batch_effect_corrected"]], col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-    title(main="After batch-effects correction", ylab="RLE")
-    legend("topright", legend=levels(factor(target$Target)), fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", box.col="transparent")
-    invisible(dev.off())
 
-  } else {
-    plotRLE(ref_dataset.list[[dataset]][["combined_data_processed"]], col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-    title(main="", ylab="RLE")
-    legend("topright", legend=levels(factor(target$Target)), fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", box.col="transparent")
-    
+  if (params$batch_rm) {
+    par(mfrow = c(2, 1), mar = c(2, 5, 3, 2))
+
+    ##### Before batch-effects correction
+    plotRLE(ref_dataset.list[[dataset]][["combined_data_processed"]], col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+    title(main = "Before batch-effects correction", ylab = "RLE")
+    legend("topright", legend = levels(factor(target$Target)), fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", box.col = "transparent")
+
     ref_dataset.list[[dataset]][["rle_combined_data_processed"]] <- recordPlot()
-    
+
+    ##### After batch-effects correction
+    plotRLE(ref_dataset.list[[dataset]][["batch_effect_corrected"]], col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+    title(main = "After batch-effects correction", ylab = "RLE")
+    legend("topright", legend = levels(factor(target$Target)), fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", box.col = "transparent")
+
+    ref_dataset.list[[dataset]][["rle_batch_effect_corrected"]] <- recordPlot()
+
+
     ##### Save the plot as png file
-    png(paste0(PlotsDir, "/rle.png"), width=900, height=450, pointsize = 14)
-  
-    plotRLE(ref_dataset.list[[dataset]][["combined_data_processed"]], col=targets.colour[[2]], main="", pch="", las=3, xaxt="n", outline = FALSE)
-    title(main="", ylab="RLE")
-    legend("topright", legend=levels(factor(target$Target)), fill=targets.colour[[1]], horiz=TRUE, bg = "transparent", box.col="transparent")
+    png(paste0(PlotsDir, "/rle.png"), width = 900, height = 700, pointsize = 14)
+    par(mfrow = c(2, 1), mar = c(2, 5, 3, 2))
+
+    ##### Before batch-effects correction
+    plotRLE(ref_dataset.list[[dataset]][["combined_data_processed"]], col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+    title(main = "Before batch-effects correction", ylab = "RLE")
+    legend("topright", legend = levels(factor(target$Target)), fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", box.col = "transparent")
+
+    ##### After batch-effects correction
+    plotRLE(ref_dataset.list[[dataset]][["batch_effect_corrected"]], col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+    title(main = "After batch-effects correction", ylab = "RLE")
+    legend("topright", legend = levels(factor(target$Target)), fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", box.col = "transparent")
+    invisible(dev.off())
+  } else {
+    plotRLE(ref_dataset.list[[dataset]][["combined_data_processed"]], col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+    title(main = "", ylab = "RLE")
+    legend("topright", legend = levels(factor(target$Target)), fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", box.col = "transparent")
+
+    ref_dataset.list[[dataset]][["rle_combined_data_processed"]] <- recordPlot()
+
+    ##### Save the plot as png file
+    png(paste0(PlotsDir, "/rle.png"), width = 900, height = 450, pointsize = 14)
+
+    plotRLE(ref_dataset.list[[dataset]][["combined_data_processed"]], col = targets.colour[[2]], main = "", pch = "", las = 3, xaxt = "n", outline = FALSE)
+    title(main = "", ylab = "RLE")
+    legend("topright", legend = levels(factor(target$Target)), fill = targets.colour[[1]], horiz = TRUE, bg = "transparent", box.col = "transparent")
     invisible(dev.off())
   }
 }
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 
 ##### Clean the space
 rm(targets.colour, den, y)
@@ -1373,8 +1343,7 @@ rm(targets.colour, den, y)
 
 ```{r gene_annot_count_data, comment = NA, message=FALSE, warning=FALSE}
 ##### Loop through combined, BUT NOT PROCESSED, datasets and annotate ALL genes. This part is mainly required for biotype detection step
-for ( dataset in names(ref_dataset.list) ) {
-  
+for (dataset in names(ref_dataset.list)) {
   ##### Convert data into a data frame to make the Ensembl ID and gene symbol matches (with merge function)
   data <- ref_dataset.list[[dataset]][["combined_data"]]
   data.df <- as.data.frame(cbind(rownames(data), data))
@@ -1382,59 +1351,59 @@ for ( dataset in names(ref_dataset.list) ) {
 
   ##### Get genes annotation and genomic locations
   edb <- eval(parse(text = paste0("EnsDb.Hsapiens.v", params$ensembl_version)))
-  
+
   ##### Get keytypes for gene SYMBOL
-  keys <- keys(edb, keytype="GENEID")
-  
+  keys <- keys(edb, keytype = "GENEID")
+
   ##### Get genes genomic coordiantes
-  gene_info <- ensembldb::select(edb, keys=keys, columns=c("GENEID", "GENEBIOTYPE", "GENENAME", "SEQNAME", "GENESEQSTART", "GENESEQEND"), keytype="GENEID")
+  gene_info <- ensembldb::select(edb, keys = keys, columns = c("GENEID", "GENEBIOTYPE", "GENENAME", "SEQNAME", "GENESEQSTART", "GENESEQEND"), keytype = "GENEID")
   names(gene_info) <- gsub("GENEID", "ENSEMBL", names(gene_info))
   names(gene_info) <- gsub("GENENAME", "SYMBOL", names(gene_info))
-  
+
   ##### Limit genes annotation to those genes for which sample expression measurments are available
-  gene_info <-  gene_info[ gene_info$ENSEMBL %in% data.df$ENSEMBL,  ]
-  
+  gene_info <- gene_info[gene_info$ENSEMBL %in% data.df$ENSEMBL, ]
+
   ##### Remove rows with duplicated ENSEMBL IDs
-  gene_info = gene_info[!duplicated(gene_info$ENSEMBL),]
+  gene_info <- gene_info[!duplicated(gene_info$ENSEMBL), ]
   rownames(gene_info) <- gene_info$ENSEMBL
-  
+
   ##### Remove rows with duplicated gene symbols (Y_RNAs, SNORs, LINC0s etc)
-  gene_info = gene_info[!duplicated(gene_info$SYMBOL),]
-  
+  gene_info <- gene_info[!duplicated(gene_info$SYMBOL), ]
+
   ##### Add info about immune response markers
   gene_info.immune_markers <- merge(gene_info, ref_genes.list[["genes_immune"]]$immune_markers, by = "SYMBOL", all.x = TRUE)
-  
+
   ##### Keep only immune response markers for which there is available annotation
-  ref_genes.list[["genes_immune"]]$immune_markers <- ref_genes.list[["genes_immune"]]$immune_markers[ ref_genes.list[["genes_immune"]]$immune_markers$SYMBOL %in% gene_info.immune_markers$SYMBOL, ]
-  
+  ref_genes.list[["genes_immune"]]$immune_markers <- ref_genes.list[["genes_immune"]]$immune_markers[ref_genes.list[["genes_immune"]]$immune_markers$SYMBOL %in% gene_info.immune_markers$SYMBOL, ]
+
   ##### Add info about immunogram genes
-  if ( params$immunogram ) {
+  if (params$immunogram) {
     gene_info.immunogram <- merge(gene_info, ref_genes.list[["genes_immune"]]$immunogram, by = "SYMBOL", all.x = TRUE)
-    gene_info.immunogram <- gene_info.immunogram[!duplicated(gene_info.immunogram[,"ENSEMBL"]),]
-    
+    gene_info.immunogram <- gene_info.immunogram[!duplicated(gene_info.immunogram[, "ENSEMBL"]), ]
+
     ##### Keep only immunogram genes for which there is available annotation
-    ref_genes.list[["genes_immune"]]$immunogram <- ref_genes.list[["genes_immune"]]$immunogram[ ref_genes.list[["genes_immune"]]$immunogram$SYMBOL %in% gene_info.immunogram$SYMBOL, ]
-    
+    ref_genes.list[["genes_immune"]]$immunogram <- ref_genes.list[["genes_immune"]]$immunogram[ref_genes.list[["genes_immune"]]$immunogram$SYMBOL %in% gene_info.immunogram$SYMBOL, ]
+
     ##### Merge genes annotations for immunogram genes and immune markers
-    gene_info <- merge( gene_info.immunogram, gene_info.immune_markers[ , c("ENSEMBL", "Immune_Cycle_Role") ], by = "ENSEMBL")
+    gene_info <- merge(gene_info.immunogram, gene_info.immune_markers[, c("ENSEMBL", "Immune_Cycle_Role")], by = "ENSEMBL")
   } else {
     gene_info <- gene_info.immune_markers
   }
-  
+
   ##### Merge genes genomic coordinates info with their annotation and expression data
   data.annot <- merge(gene_info, data.df, by = "ENSEMBL", all.x = FALSE)
   rownames(data.annot) <- data.annot$ENSEMBL
-  
+
   ##### Get data matrix with gene symbols
-  if ( params$immunogram ) {
+  if (params$immunogram) {
     ref_dataset.list[[dataset]][["gene_annot_all"]] <- data.annot[, c("SYMBOL", "GENEBIOTYPE", "ENSEMBL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "CIC", "Immune_Cycle_Role")]
   } else {
     ref_dataset.list[[dataset]][["gene_annot_all"]] <- data.annot[, c("SYMBOL", "GENEBIOTYPE", "ENSEMBL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "Immune_Cycle_Role")]
   }
-  
+
   ##### Save the combined expression matrix, genes list and associated targets into txt files
-  write.table(prepare2write(ref_dataset.list[[dataset]][["combined_data"]]), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.combined_data.txt"), sep="\t", quote=FALSE, row.names=FALSE, col.names=TRUE, append = FALSE )
-  write.table(prepare2write(ref_dataset.list[[dataset]][["gene_annot_all"]]), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.gene_annot_all.txt"), sep="\t", quote=FALSE, row.names=FALSE, col.names=TRUE, append = FALSE )
+  write.table(prepare2write(ref_dataset.list[[dataset]][["combined_data"]]), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.combined_data.txt"), sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = FALSE)
+  write.table(prepare2write(ref_dataset.list[[dataset]][["gene_annot_all"]]), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.gene_annot_all.txt"), sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = FALSE)
 }
 
 ##### Clean the space
@@ -1443,29 +1412,28 @@ rm(data, target, data.df, edb, keys)
 
 ```{r gene_annot_processed_data, comment = NA, message=FALSE, warning=FALSE}
 ##### Loop through combined datasets and annotate genes
-for ( dataset in names(ref_dataset.list) ) {
-  
+for (dataset in names(ref_dataset.list)) {
   ##### Convert data into a data frame to make the Ensembl ID and gene symbol matches (with merge function)
   data <- ref_dataset.list[[dataset]][["data_to_report"]]
   data.df <- as.data.frame(cbind(rownames(data), data))
   colnames(data.df)[1] <- "ENSEMBL"
-  
+
   ##### Merge genes genomic coordinates info with their annotation and expression data
   data.annot <- merge(gene_info, data.df, by = "ENSEMBL", all.x = FALSE)
-  
+
   ##### Keep only genes fo which gene symbol is available
-  data.annot <- data.annot[!(is.na(data.annot$SYMBOL) | data.annot$SYMBOL==""), ]
+  data.annot <- data.annot[!(is.na(data.annot$SYMBOL) | data.annot$SYMBOL == ""), ]
   rownames(data.annot) <- data.annot$SYMBOL
-  
+
   ##### Get data matrix with gene symbols
   ref_dataset.list[[dataset]][["data_to_report"]] <- apply(data.annot[, colnames(data)], 2, as.numeric)
   rownames(ref_dataset.list[[dataset]][["data_to_report"]]) <- data.annot$SYMBOL
   ref_dataset.list[[dataset]][["gene_annot"]] <- data.annot[, c("SYMBOL", "GENEBIOTYPE", "ENSEMBL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "Immune_Cycle_Role")]
-  
+
   ##### Save the combined expression matrix, genes list and associated targets into txt files
-  write.table(prepare2write(ref_dataset.list[[dataset]][["data_to_report"]]), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.combined_data_processed.txt"), sep="\t", quote=FALSE, row.names=FALSE, col.names=TRUE, append = FALSE )
-  write.table(prepare2write(toupper(rownames(ref_dataset.list[[dataset]][["data_to_report"]]))), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.combined_data_processed.genes.txt"), sep="\t", quote=FALSE, row.names=FALSE, col.names=TRUE, append = FALSE )
-  write.table(prepare2write(ref_dataset.list[[dataset]][["sample_annot"]]), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.sample_annot.txt"), sep="\t", quote=FALSE, row.names=FALSE, col.names=TRUE, append = FALSE )
+  write.table(prepare2write(ref_dataset.list[[dataset]][["data_to_report"]]), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.combined_data_processed.txt"), sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = FALSE)
+  write.table(prepare2write(toupper(rownames(ref_dataset.list[[dataset]][["data_to_report"]]))), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.combined_data_processed.genes.txt"), sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = FALSE)
+  write.table(prepare2write(ref_dataset.list[[dataset]][["sample_annot"]]), file = paste0(results_dir, "/", sample_name, ".RNAseq_report.sample_annot.txt"), sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = FALSE)
 }
 
 ##### Clean the space
@@ -1479,21 +1447,21 @@ targets <- ref_dataset.list[[dataset]][["sample_annot"]]
 data <- ref_dataset.list[[dataset]][["data_to_report"]]
 
 ##### Percentiles
-genes.expr.perc <- exprTable( genes = rownames(data), keep_all = TRUE, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+genes.expr.perc <- exprTable(genes = rownames(data), keep_all = TRUE, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 
 ##### Z-scores
-genes.expr.z <- exprTable( genes = rownames(data), keep_all = TRUE, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+genes.expr.z <- exprTable(genes = rownames(data), keep_all = TRUE, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 
 ##### Create directory for saving tables
 exprTableDir <- paste(results_dir, "exprTables", sep = "/")
-    
-if ( !file.exists(exprTableDir) ) {
-  dir.create(exprTableDir, recursive=TRUE)
+
+if (!file.exists(exprTableDir)) {
+  dir.create(exprTableDir, recursive = TRUE)
 }
 
 ##### Save the expression tables as html file
-saveWidgetFix(widget=genes.expr.perc[[1]], file=paste(exprTableDir, "genes.expr.perc.html", sep = "/"), selfcontained=TRUE)
-saveWidgetFix(widget=genes.expr.z[[1]], file=paste(exprTableDir, "genes.expr.z.html", sep = "/"), selfcontained=TRUE)
+saveWidgetFix(widget = genes.expr.perc[[1]], file = paste(exprTableDir, "genes.expr.perc.html", sep = "/"), selfcontained = TRUE)
+saveWidgetFix(widget = genes.expr.z[[1]], file = paste(exprTableDir, "genes.expr.z.html", sep = "/"), selfcontained = TRUE)
 
 ##### Clean the space
 rm(data, targets, genes.expr.z, genes.expr.perc)
@@ -1506,22 +1474,22 @@ expr_data <- ref_dataset.list[[dataset]][["data_to_report"]]
 targets <- ref_dataset.list[[dataset]][["sample_annot"]]
 
 ##### ...percerntiles
-expr_data.perc <- exprTable( genes = rownames(expr_data), keep_all = TRUE, data = expr_data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[2]]
+expr_data.perc <- exprTable(genes = rownames(expr_data), keep_all = TRUE, data = expr_data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[2]]
 
 expr_genes <- expr_data.perc$SYMBOL
 
 ##### Get the "Diff" (Patient vs [comp_cancer]) Z-scores using exprTable function
-expr_data.z <- exprTable( genes = expr_genes, keep_all = TRUE, data = expr_data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[2]]
+expr_data.z <- exprTable(genes = expr_genes, keep_all = TRUE, data = expr_data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[2]]
 
 ##### Make sure the tables have the same genes order
-expr_data.perc <- expr_data.perc[ expr_genes, ]
+expr_data.perc <- expr_data.perc[expr_genes, ]
 
-if ( comp_cancer_group != int_cancer_group ) {
-  expr_data.perc <- expr_data.perc[, "Diff" ]
-  expr_data.z <- expr_data.z[, "Diff" ]
+if (comp_cancer_group != int_cancer_group) {
+  expr_data.perc <- expr_data.perc[, "Diff"]
+  expr_data.z <- expr_data.z[, "Diff"]
 } else {
-  expr_data.perc <- expr_data.perc[, paste0( "Patient vs ", comp_cancer_group)]
-  expr_data.z <- expr_data.z[, paste0( "Patient vs ", comp_cancer_group)]
+  expr_data.perc <- expr_data.perc[, paste0("Patient vs ", comp_cancer_group)]
+  expr_data.z <- expr_data.z[, paste0("Patient vs ", comp_cancer_group)]
 }
 
 names(expr_data.perc) <- expr_genes
@@ -1529,12 +1497,12 @@ names(expr_data.z) <- expr_genes
 
 ##### Calculate the mean CN for each gene
 cn_data$MeanCopyNumber <- rowMeans(cbind(cn_data$MinCopyNumber, cn_data$MaxCopyNumber))
-  
+
 ##### Deal with negative CN values
-cn_data$MeanCopyNumber[ cn_data$MeanCopyNumber < 0 ] <- 0
+cn_data$MeanCopyNumber[cn_data$MeanCopyNumber < 0] <- 0
 
 ##### Remove entries with missing gene symbol (mainly variants in intergenic regions)
-cn_data <- cn_data[ cn_data$Gene %!in% "", ]
+cn_data <- cn_data[cn_data$Gene %!in% "", ]
 
 ##### Keep only altered genes with CN values below loss threshold (default 5th percentile) and above gain threshold (default 95th percentile)
 cn_data.all <- cn_data
@@ -1543,14 +1511,14 @@ cn_data.all <- cn_data
 cn_data.all.percent <- quantile(cn_data.all$MeanCopyNumber, probs = seq(0, 1, .05), na.rm = TRUE)
 
 ##### Keep only genes with available expression data
-cn_data <- cn_data[ cn_data$Gene %in% names(expr_data.z), ]
+cn_data <- cn_data[cn_data$Gene %in% names(expr_data.z), ]
 
 ##### Add mutation data if available
-if ( !is.null(ref_genes.list[["pcgr"]]) ) {
+if (!is.null(ref_genes.list[["pcgr"]])) {
   mut_data <- ref_genes.list[["pcgr"]]
-  
+
   ##### Remove entries with missing gene symbol (mainly variants in intergenic regions)
-  mut_data <- mut_data[ mut_data$SYMBOL %!in% "", ]
+  mut_data <- mut_data[mut_data$SYMBOL %!in% "", ]
 
   ##### Prepare mutation data to include multiple mutations per gene
   ##### Initiate variable for the gene mutation status for each gene
@@ -1558,34 +1526,32 @@ if ( !is.null(ref_genes.list[["pcgr"]]) ) {
   colnames(gene.mut) <- "Alterations"
   rownames(gene.mut) <- names(expr_data.z)
 
-  for ( i in 1:nrow(gene.mut) ) {
+  for (i in 1:nrow(gene.mut)) {
     ##### Check if any mutations are reported for each gene
-    if (  rownames(gene.mut)[i] %in% mut_data$SYMBOL ) {
-    
+    if (rownames(gene.mut)[i] %in% mut_data$SYMBOL) {
       ##### Deal with multiple mutations per gene
-      if ( length(mut_data[ mut_data$SYMBOL %in% rownames(gene.mut)[i],  ]$CONSEQUENCE) > 1 ) {
-        gene.mut[ rownames(gene.mut)[i],"Alterations" ] <- "Mutation: multiple hits"
+      if (length(mut_data[mut_data$SYMBOL %in% rownames(gene.mut)[i], ]$CONSEQUENCE) > 1) {
+        gene.mut[rownames(gene.mut)[i], "Alterations"] <- "Mutation: multiple hits"
       } else {
-        gene.mut[ rownames(gene.mut)[i],"Alterations" ] <- paste0("Mutation: ", mut_data[ mut_data$SYMBOL %in% rownames(gene.mut)[i],  ]$CONSEQUENCE)
+        gene.mut[rownames(gene.mut)[i], "Alterations"] <- paste0("Mutation: ", mut_data[mut_data$SYMBOL %in% rownames(gene.mut)[i], ]$CONSEQUENCE)
       }
     }
   }
 
   ##### If there is no expression value for a specific gene than assume it's not expressed at all and assign the lowest value observed in that sample
-  for ( gene in unique(mut_data$SYMBOL) ) {
-    if ( gene %!in% rownames(gene.mut) ) {
-      
+  for (gene in unique(mut_data$SYMBOL)) {
+    if (gene %!in% rownames(gene.mut)) {
       expr_data.perc <- c(expr_data.perc, min(expr_data.perc))
       names(expr_data.perc)[length(expr_data.perc)] <- gene
-      
+
       expr_data.z <- c(expr_data.z, min(expr_data.z))
       names(expr_data.z)[length(expr_data.z)] <- gene
-      
+
       ##### Deal with multiple mutations per gene
-      if ( length(mut_data[ mut_data$SYMBOL %in% gene,  ]$CONSEQUENCE) > 1 ) {
-        gene.mut <- rbind( gene.mut,  "multiple hits")
+      if (length(mut_data[mut_data$SYMBOL %in% gene, ]$CONSEQUENCE) > 1) {
+        gene.mut <- rbind(gene.mut, "multiple hits")
       } else {
-        gene.mut <- rbind( gene.mut,  mut_data[ mut_data$SYMBOL %in% gene,  ]$CONSEQUENCE )
+        gene.mut <- rbind(gene.mut, mut_data[mut_data$SYMBOL %in% gene, ]$CONSEQUENCE)
       }
       rownames(gene.mut)[nrow(gene.mut)] <- gene
     }
@@ -1593,38 +1559,37 @@ if ( !is.null(ref_genes.list[["pcgr"]]) ) {
 
   ##### Subset expression, mutation and copy-number data to include only overlapping genes
   genes.intersect <- intersect(intersect(rownames(gene.mut), cn_data$Gene), names(expr_data.perc))
-  
-  gene.mut.sub <- gene.mut[ rownames(gene.mut) %in% genes.intersect, ]
-  cn_data.sub <- cn_data[ cn_data$Gene %in% genes.intersect, ]
-  expr_data.perc.sub <- expr_data.perc[ names(expr_data.perc) %in% genes.intersect ]
-  expr_data.z.sub <- expr_data.z[ names(expr_data.z) %in% genes.intersect ]
-  
+
+  gene.mut.sub <- gene.mut[rownames(gene.mut) %in% genes.intersect, ]
+  cn_data.sub <- cn_data[cn_data$Gene %in% genes.intersect, ]
+  expr_data.perc.sub <- expr_data.perc[names(expr_data.perc) %in% genes.intersect]
+  expr_data.z.sub <- expr_data.z[names(expr_data.z) %in% genes.intersect]
+
   ##### Make sure thay are all in the same order
-  gene.mut.sub <- gene.mut.sub[ genes.intersect ]
+  gene.mut.sub <- gene.mut.sub[genes.intersect]
   rownames(cn_data.sub) <- cn_data.sub$Gene
-  cn_data.sub <- cn_data.sub[ genes.intersect,  ]
-  expr_data.perc.sub <- expr_data.perc.sub[ genes.intersect  ]
-  expr_data.z.sub <- expr_data.z.sub[ genes.intersect  ]
-  
+  cn_data.sub <- cn_data.sub[genes.intersect, ]
+  expr_data.perc.sub <- expr_data.perc.sub[genes.intersect]
+  expr_data.z.sub <- expr_data.z.sub[genes.intersect]
+
   ##### Prepare data frame
   cn_data.sub <- data.frame(names(expr_data.z.sub), cn_data.sub$MeanCopyNumber, expr_data.perc.sub, expr_data.z.sub, gene.mut.sub)
   colnames(cn_data.sub) <- c("Gene", "CN", "Perc_diff", "Z_score_diff", "Alterations")
-  
 } else {
   ##### Skip the step for processing mutation info and deal with expression and copy-number data
   ##### Subset expression and copy-number data to include only overlapping genes
   genes.intersect <- intersect(cn_data$Gene, names(expr_data.perc))
-  
-  cn_data.sub <- cn_data[ cn_data$Gene %in% genes.intersect, ]
-  expr_data.perc.sub <- expr_data.perc[ names(expr_data.perc) %in% genes.intersect ]
-  expr_data.z.sub <- expr_data.z[ names(expr_data.z) %in% genes.intersect ]
-  
+
+  cn_data.sub <- cn_data[cn_data$Gene %in% genes.intersect, ]
+  expr_data.perc.sub <- expr_data.perc[names(expr_data.perc) %in% genes.intersect]
+  expr_data.z.sub <- expr_data.z[names(expr_data.z) %in% genes.intersect]
+
   ##### Make sure thay are all in the same order
   rownames(cn_data.sub) <- cn_data.sub$Gene
-  cn_data.sub <- cn_data.sub[ genes.intersect,  ]
-  expr_data.perc.sub <- expr_data.perc.sub[ genes.intersect  ]
-  expr_data.z.sub <- expr_data.z.sub[ genes.intersect  ]
-  
+  cn_data.sub <- cn_data.sub[genes.intersect, ]
+  expr_data.perc.sub <- expr_data.perc.sub[genes.intersect]
+  expr_data.z.sub <- expr_data.z.sub[genes.intersect]
+
   ##### Prepare data frame
   cn_data.sub <- data.frame(names(expr_data.z.sub), cn_data.sub$MeanCopyNumber, expr_data.perc.sub, expr_data.z.sub)
   colnames(cn_data.sub) <- c("Gene", "CN", "Perc_diff", "Z_score_diff")
@@ -1633,10 +1598,10 @@ if ( !is.null(ref_genes.list[["pcgr"]]) ) {
 ref_dataset.list[[dataset]][["expr_mut_cn_data_all"]] <- cn_data.sub
 
 ##### Limit the data to include only cancer genes
-cn_data.sub <- cn_data.sub[ cn_data.sub$Gene %in% rownames(ref_genes.list[["genes_cancer"]]), ]
+cn_data.sub <- cn_data.sub[cn_data.sub$Gene %in% rownames(ref_genes.list[["genes_cancer"]]), ]
 
 ##### Keep genes meeting the user-defined CN values thresholds
-ref_dataset.list[[dataset]][["expr_mut_cn_data"]] <- cn_data.sub[ cn_data.sub$CN <= cn_bottom | cn_data.sub$CN >= cn_top, ]
+ref_dataset.list[[dataset]][["expr_mut_cn_data"]] <- cn_data.sub[cn_data.sub$CN <= cn_bottom | cn_data.sub$CN >= cn_top, ]
 
 ##### Clean the space
 rm(cn_data, cn_data.sub, expr_data, gene.mut, mut_data, targets, expr_data.z, expr_data.perc, expr_data.z.sub, expr_data.perc.sub, expr_genes, gene.mut.sub, genes.intersect)
@@ -1646,30 +1611,32 @@ rm(cn_data, cn_data.sub, expr_data, gene.mut, mut_data, targets, expr_data.z, ex
 suppressMessages(library(plotly))
 
 ##### Draw histogram of CN data
-cn_dist_plot <- plot_ly(x = cn_data.all$MeanCopyNumber, type = 'histogram', name = "CN data", width = 800, height = 300) %>%
-  
+cn_dist_plot <- plot_ly(x = cn_data.all$MeanCopyNumber, type = "histogram", name = "CN data", width = 800, height = 300) %>%
   ##### Add 5th percentile threshold
-  add_lines(y = seq(0,1000, 100), x = rep(cn_data.all.percent[2],11), 
-              line = list(color = "black", dash = "dash"), opacity = 0.4,
-              name = "5th percentile", showlegend = TRUE) %>%
-  
+  add_lines(
+    y = seq(0, 1000, 100), x = rep(cn_data.all.percent[2], 11),
+    line = list(color = "black", dash = "dash"), opacity = 0.4,
+    name = "5th percentile", showlegend = TRUE
+  ) %>%
   ##### Add 50th percentile
-  add_lines(y = seq(0,1000, 100), x = rep(cn_data.all.percent[11],11), 
-              line = list(color = "black", dash = "dash"), opacity = 0.7,
-              name = "50th percentile", showlegend = TRUE) %>%
-  
+  add_lines(
+    y = seq(0, 1000, 100), x = rep(cn_data.all.percent[11], 11),
+    line = list(color = "black", dash = "dash"), opacity = 0.7,
+    name = "50th percentile", showlegend = TRUE
+  ) %>%
   ##### Add 95th percentile threshold
-  add_lines(y = seq(0,1000, 100), x = rep(cn_data.all.percent[20],11), 
-              line = list(color = "black", dash = "dash"), opacity = 1,
-              name = "95th percentile", showlegend = TRUE) %>%
-  
-  layout(xaxis = list( title = "CN values"), yaxis = list( title = "Frequency"), margin = list(l=50, r=50, b=50, t=50, pad=4), autosize = F)
+  add_lines(
+    y = seq(0, 1000, 100), x = rep(cn_data.all.percent[20], 11),
+    line = list(color = "black", dash = "dash"), opacity = 1,
+    name = "95th percentile", showlegend = TRUE
+  ) %>%
+  layout(xaxis = list(title = "CN values"), yaxis = list(title = "Frequency"), margin = list(l = 50, r = 50, b = 50, t = 50, pad = 4), autosize = F)
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 
 ##### Clean the space
 rm(cn_data.all)
@@ -1681,20 +1648,20 @@ known_translocations.CGI <- caner_genes_annot.list[["cancer_biomarkers_trans"]]
 known_translocations.CGI$cancer_acronym <- gsub(";", ", ", known_translocations.CGI$cancer_acronym)
 known_translocations.CGI$source <- gsub(";", ", ", known_translocations.CGI$source)
 known_translocations.CGI$translocation <- gsub("__", "_", known_translocations.CGI$translocation)
-  
+
 ##### Flag known fusions based on info from FusionGDB (https://ccsm.uth.edu/FusionGDB)
 known_translocations.FusionGDB <- caner_genes_annot.list[["FusionGDB"]]
-  
+
 ##### Merge info from both resources
-known_translocations <- merge(known_translocations.FusionGDB, known_translocations.CGI, by.x = "FGname", by.y = "translocation", all = TRUE, sort=FALSE)
-  
+known_translocations <- merge(known_translocations.FusionGDB, known_translocations.CGI, by.x = "FGname", by.y = "translocation", all = TRUE, sort = FALSE)
+
 ##### Extract gene pairs involved in reported gene fusions
-trans.pairs <- as.data.frame(cbind( known_translocations$FGname, known_translocations$FGname ))
+trans.pairs <- as.data.frame(cbind(known_translocations$FGname, known_translocations$FGname))
 names(trans.pairs) <- c("geneA", "geneB")
 trans.pairs$geneA <- sub("_.*", "", trans.pairs$geneA)
 trans.pairs$geneB <- sub(".*_", "", trans.pairs$geneB)
 known_translocations <- cbind(known_translocations, trans.pairs)
-trans.pairs <- apply( trans.pairs , 1 , paste , collapse = "-" )
+trans.pairs <- apply(trans.pairs, 1, paste, collapse = "-")
 ```
 
 ```{r arriba_filtering, comment = NA, message=FALSE, warning=FALSE, eval = runArribaChunk}
@@ -1705,79 +1672,75 @@ colnames(arriba.fusions) <- gsub("1", "A", colnames(arriba.fusions))
 colnames(arriba.fusions) <- gsub("2", "B", colnames(arriba.fusions))
 
 #####  Note the fusions order, which will be later required for imbedding Arriba plots from corresponding pdf booklet pages
-arriba.fusions.order <- paste(arriba.fusions$geneA, arriba.fusions$geneB, sep="__")
+arriba.fusions.order <- paste(arriba.fusions$geneA, arriba.fusions$geneB, sep = "__")
 
 ##### Extract only those fusion genes that are in cancer genes list
 arriba.cancer_genes <- data.frame()
 
-for (row in 1:nrow(arriba.fusions)){
-  if(arriba.fusions[row,"geneA"] %in% rownames(ref_genes.list[["genes_cancer"]]) | arriba.fusions[row,"geneB"] %in% rownames(ref_genes.list[["genes_cancer"]])) {
-    
+for (row in 1:nrow(arriba.fusions)) {
+  if (arriba.fusions[row, "geneA"] %in% rownames(ref_genes.list[["genes_cancer"]]) | arriba.fusions[row, "geneB"] %in% rownames(ref_genes.list[["genes_cancer"]])) {
     ##### Creating a new dataframe for extracting arriba rows with cancer gene hits
-    arriba.cancer_genes <- rbind(arriba.cancer_genes, data.frame(arriba.fusions[row,]))
+    arriba.cancer_genes <- rbind(arriba.cancer_genes, data.frame(arriba.fusions[row, ]))
   }
 }
 
 ##### Add columns for info about reported fusions
 fusions <- cbind(arriba.fusions, data.frame(matrix("", ncol = 5, nrow = nrow(arriba.fusions)), stringsAsFactors = FALSE))
-colnames(fusions)[(ncol(fusions)-4):ncol(fusions)] <- c("FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene")
-  
+colnames(fusions)[(ncol(fusions) - 4):ncol(fusions)] <- c("FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene")
+
 ##### Add annotations about known fusion events
 ##### Loop through all genes involved in deteced gene fusions (arriba results) and check which are already reported
-for ( i in 1:nrow(fusions) ) {
+for (i in 1:nrow(fusions)) {
   geneA <- as.character(fusions$geneA[i])
   geneB <- as.character(fusions$geneB[i])
-          
+
   ##### First check if the exact reported gene pairs were detected by arriba
-  if ( paste(geneA, geneB, sep="-") %in% trans.pairs ) {
-      
+  if (paste(geneA, geneB, sep = "-") %in% trans.pairs) {
     ##### provide fusion URL to FusionGDB
     fusions$reported_fusion[i] <- "Yes"
-      
+
     ##### provide fusion ID from FusionGDB
-    fusions$FGID[i] <- known_translocations$FGID[ trans.pairs %in% paste(geneA, geneB, sep="-")  ]
-      
+    fusions$FGID[i] <- known_translocations$FGID[trans.pairs %in% paste(geneA, geneB, sep = "-")]
+
     fusions$reported_fusion_geneA[i] <- "Yes"
     fusions$reported_fusion_geneB[i] <- "Yes"
-      
-  } else if ( paste(geneB, geneA, sep="-") %in% trans.pairs ) {
-      
+  } else if (paste(geneB, geneA, sep = "-") %in% trans.pairs) {
     ##### provide fusion URL to FusionGDB
     fusions$reported_fusion[i] <- "Yes"
-      
+
     ##### provide fusion ID from FusionGDB
-    fusions$FGID[i] <- known_translocations$FGID[ trans.pairs %in% paste(geneB, geneA, sep="-")  ]
-      
+    fusions$FGID[i] <- known_translocations$FGID[trans.pairs %in% paste(geneB, geneA, sep = "-")]
+
     fusions$reported_fusion_geneA[i] <- "Yes"
     fusions$reported_fusion_geneB[i] <- "Yes"
-      
-  ##### Now check if any ofthe arriba detected fusion genes are reported
+
+    ##### Now check if any ofthe arriba detected fusion genes are reported
   } else {
     fusions$reported_fusion[i] <- "-"
-      
+
     ##### Check the Cancer Genome Interpreter (CGI) database first
     ##### Check arriba genes A and genes A in reported fusions
-    if ( geneA %in% known_translocations$geneA ) {
-       fusions$reported_fusion_geneA[i] <- "Yes"
-        
-    ##### Check arriba genes A and genes B in reported fusions
-    } else if ( geneA %in% known_translocations$geneB ) {
+    if (geneA %in% known_translocations$geneA) {
+      fusions$reported_fusion_geneA[i] <- "Yes"
+
+      ##### Check arriba genes A and genes B in reported fusions
+    } else if (geneA %in% known_translocations$geneB) {
       fusions$reported_fusion_geneA[i] <- "Yes"
     }
-      
+
     ##### Check arriba genes B and genes A in reported fusions
-    if ( geneB %in% known_translocations$geneA ) {
+    if (geneB %in% known_translocations$geneA) {
       fusions$reported_fusion_geneB[i] <- "Yes"
-        
-    ##### Check arriba genes B and genes B in reported fusions
-    } else if ( geneB %in% known_translocations$geneB ) {
+
+      ##### Check arriba genes B and genes B in reported fusions
+    } else if (geneB %in% known_translocations$geneB) {
       fusions$reported_fusion_geneB[i] <- "Yes"
     }
-      
+
     ##### Flag if any of the genes are effector gene
-    if ( geneA %in% known_translocations$effector_gene  ) {
+    if (geneA %in% known_translocations$effector_gene) {
       fusions$effector_gene[i] <- geneA
-    } else if ( geneB == known_translocations$effector_gene  ) {
+    } else if (geneB == known_translocations$effector_gene) {
       fusions$effector_gene[i] <- geneB
     }
   }
@@ -1789,23 +1752,23 @@ fusions$split_reads <- fusions$split_readsA + fusions$split_readsB
 ##### Add column indicating fusions containing known cancer genes
 fusions$fusions_cancer <- c(rep("-", nrow(fusions)))
 
-if ( nrow(arriba.cancer_genes) > 0 ) {
-  fusions$fusions_cancer[ fusions$geneA %in% arriba.cancer_genes$geneA ] <- "Yes"
-  fusions$fusions_cancer[ fusions$geneB %in% arriba.cancer_genes$geneB ] <- "Yes"
+if (nrow(arriba.cancer_genes) > 0) {
+  fusions$fusions_cancer[fusions$geneA %in% arriba.cancer_genes$geneA] <- "Yes"
+  fusions$fusions_cancer[fusions$geneB %in% arriba.cancer_genes$geneB] <- "Yes"
 }
 
 ##### Re-ordering arriba's results on the basis of Arriba's confidence, reported fusions and then read count values (first by split count and then paircount) and then involvment of cancer genes and reported one of the fusion genes
-fusions <- fusions[ order(fusions$reported_fusion, fusions$split_reads, fusions$split_readsA, fusions$split_readsB, fusions$discordant_mates, fusions$fusions_cancer, fusions$reported_fusion_geneA, fusions$reported_fusion_geneB, decreasing = TRUE), ]
-fusions <- fusions[order(factor(fusions$confidence, levels=c("high", "medium", "low"))), ]
+fusions <- fusions[order(fusions$reported_fusion, fusions$split_reads, fusions$split_readsA, fusions$split_readsB, fusions$discordant_mates, fusions$fusions_cancer, fusions$reported_fusion_geneA, fusions$reported_fusion_geneB, decreasing = TRUE), ]
+fusions <- fusions[order(factor(fusions$confidence, levels = c("high", "medium", "low"))), ]
 
-##### Keep only key columns and add info about Arriba detected fusions and 
-fusions <- fusions[ colnames(fusions) %in% c("geneA", "geneB", "breakpointA", "breakpointB", "siteA", "siteB", "type", "split_reads", "split_readsA", "split_readsB", "discordant_mates", "confidence", "FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene", "fusions_cancer")]
+##### Keep only key columns and add info about Arriba detected fusions and
+fusions <- fusions[colnames(fusions) %in% c("geneA", "geneB", "breakpointA", "breakpointB", "siteA", "siteB", "type", "split_reads", "split_readsA", "split_readsB", "discordant_mates", "confidence", "FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene", "fusions_cancer")]
 
 ##### Add column to flag fusions supported by WGS data (from MANTA), if available
 fusions$geneA_dna_support <- "-"
 fusions$geneB_dna_support <- "-"
 
-if ( runPizzlyChunk || runDragenFusionChunk ) {
+if (runPizzlyChunk || runDragenFusionChunk) {
   fusions$Arriba <- c(rep("Yes", nrow(fusions)))
 }
 
@@ -1824,160 +1787,150 @@ colnames(dragen.fusions) <- gsub("2", "B", colnames(dragen.fusions))
 dragen.cancer_genes <- data.frame()
 
 ##### Check if there are any fusions detected at all
-if ( nrow(dragen.fusions) > 0 ) {
-  for (row in 1:nrow(dragen.fusions)){
-    if(dragen.fusions[row,"geneA"] %in% rownames(ref_genes.list[["genes_cancer"]]) | dragen.fusions[row,"geneB"] %in% rownames(ref_genes.list[["genes_cancer"]])) {
-      
+if (nrow(dragen.fusions) > 0) {
+  for (row in 1:nrow(dragen.fusions)) {
+    if (dragen.fusions[row, "geneA"] %in% rownames(ref_genes.list[["genes_cancer"]]) | dragen.fusions[row, "geneB"] %in% rownames(ref_genes.list[["genes_cancer"]])) {
       ##### Creating a new dataframe for extracting dragen rows with cancer gene hits
-      dragen.cancer_genes <- rbind(dragen.cancer_genes, data.frame(dragen.fusions[row,]))
+      dragen.cancer_genes <- rbind(dragen.cancer_genes, data.frame(dragen.fusions[row, ]))
     }
   }
-  
+
   ##### Add columns for info about reported fusions
   dragen.fusions <- cbind(dragen.fusions, data.frame(matrix("", ncol = 5, nrow = nrow(dragen.fusions)), stringsAsFactors = FALSE))
-  colnames(dragen.fusions)[(ncol(dragen.fusions)-4):ncol(dragen.fusions)] <- c("FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene")
-  
+  colnames(dragen.fusions)[(ncol(dragen.fusions) - 4):ncol(dragen.fusions)] <- c("FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene")
+
   ##### Add annotations about known fusion events
   ##### Loop through all genes involved in deteced gene fusions (dragen results) and check which are already reported
-  for ( i in 1:nrow(dragen.fusions) ) {
+  for (i in 1:nrow(dragen.fusions)) {
     geneA <- as.character(dragen.fusions$geneA[i])
     geneB <- as.character(dragen.fusions$geneB[i])
-            
+
     ##### First check if the exact reported gene pairs were detected by dragen
-    if ( paste(geneA, geneB, sep="-") %in% trans.pairs ) {
-        
+    if (paste(geneA, geneB, sep = "-") %in% trans.pairs) {
       ##### provide fusion URL to FusionGDB
       dragen.fusions$reported_fusion[i] <- "Yes"
-        
+
       ##### provide fusion ID from FusionGDB
-      dragen.fusions$FGID[i] <- known_translocations$FGID[ trans.pairs %in% paste(geneA, geneB, sep="-")  ]
-        
+      dragen.fusions$FGID[i] <- known_translocations$FGID[trans.pairs %in% paste(geneA, geneB, sep = "-")]
+
       dragen.fusions$reported_fusion_geneA[i] <- "Yes"
       dragen.fusions$reported_fusion_geneB[i] <- "Yes"
-        
-    } else if ( paste(geneB, geneA, sep="-") %in% trans.pairs ) {
-        
+    } else if (paste(geneB, geneA, sep = "-") %in% trans.pairs) {
       ##### provide fusion URL to FusionGDB
       dragen.fusions$reported_fusion[i] <- "Yes"
-        
+
       ##### provide fusion ID from FusionGDB
-      dragen.fusions$FGID[i] <- known_translocations$FGID[ trans.pairs %in% paste(geneB, geneA, sep="-")  ]
-        
+      dragen.fusions$FGID[i] <- known_translocations$FGID[trans.pairs %in% paste(geneB, geneA, sep = "-")]
+
       dragen.fusions$reported_fusion_geneA[i] <- "Yes"
       dragen.fusions$reported_fusion_geneB[i] <- "Yes"
-        
-    ##### Now check if any of the dragen detected fusion genes are reported
+
+      ##### Now check if any of the dragen detected fusion genes are reported
     } else {
       dragen.fusions$reported_fusion[i] <- "-"
-        
+
       ##### Check the Cancer Genome Interpreter (CGI) database first
       ##### Check dragen genes A and genes B in reported fusions
-      if ( geneA %in% known_translocations$geneA ) {
-         dragen.fusions$reported_fusion_geneA[i] <- "Yes"
-          
-      ##### Check dragen genes A and genes B in reported fusions
-      } else if ( geneA %in% known_translocations$geneB ) {
+      if (geneA %in% known_translocations$geneA) {
+        dragen.fusions$reported_fusion_geneA[i] <- "Yes"
+
+        ##### Check dragen genes A and genes B in reported fusions
+      } else if (geneA %in% known_translocations$geneB) {
         dragen.fusions$reported_fusion_geneA[i] <- "Yes"
       }
-        
+
       ##### Check dragen genes B and genes A in reported fusions
-      if ( geneB %in% known_translocations$geneA ) {
+      if (geneB %in% known_translocations$geneA) {
         dragen.fusions$reported_fusion_geneB[i] <- "Yes"
-          
-      ##### Check dragen genes B and genes A in reported fusions
-      } else if ( geneB %in% known_translocations$geneB ) {
+
+        ##### Check dragen genes B and genes A in reported fusions
+      } else if (geneB %in% known_translocations$geneB) {
         dragen.fusions$reported_fusion_geneB[i] <- "Yes"
       }
-        
+
       ##### Flag if any of the genes are effector gene
-      if ( geneA %in% known_translocations$effector_gene  ) {
+      if (geneA %in% known_translocations$effector_gene) {
         dragen.fusions$effector_gene[i] <- geneA
-      } else if ( geneB == known_translocations$effector_gene  ) {
+      } else if (geneB == known_translocations$effector_gene) {
         dragen.fusions$effector_gene[i] <- geneB
       }
     }
   }
-  
+
   ##### Add column indicating fusions containing known cancer genes
   dragen.fusions$fusions_cancer <- c(rep("-", nrow(dragen.fusions)))
-  
-  if ( nrow(dragen.cancer_genes) > 0 ) {
-    dragen.fusions$fusions_cancer[ dragen.fusions$geneA %in% dragen.cancer_genes$geneA ] <- "Yes"
-    dragen.fusions$fusions_cancer[ dragen.fusions$geneB %in% dragen.cancer_genes$geneB ] <- "Yes"
+
+  if (nrow(dragen.cancer_genes) > 0) {
+    dragen.fusions$fusions_cancer[dragen.fusions$geneA %in% dragen.cancer_genes$geneA] <- "Yes"
+    dragen.fusions$fusions_cancer[dragen.fusions$geneB %in% dragen.cancer_genes$geneB] <- "Yes"
   }
-  
+
   ##### Re-ordering dragen's results on the basis of Dragen's confidence, reported fusions and then score (as Dragen doesn't includes split count and paircount info) and then involvment of cancer genes and reported one of the fusion genes
-  dragen.fusions <- dragen.fusions[ order(dragen.fusions$reported_fusion, dragen.fusions$Score, dragen.fusions$fusions_cancer, dragen.fusions$reported_fusion_geneA, dragen.fusions$reported_fusion_geneB, decreasing = TRUE), ]
-  #dragen.fusions <- dragen.fusions[order(factor(dragen.fusions$confidence, levels=c("high", "medium", "low"))), ]
-  
+  dragen.fusions <- dragen.fusions[order(dragen.fusions$reported_fusion, dragen.fusions$Score, dragen.fusions$fusions_cancer, dragen.fusions$reported_fusion_geneA, dragen.fusions$reported_fusion_geneB, decreasing = TRUE), ]
+  # dragen.fusions <- dragen.fusions[order(factor(dragen.fusions$confidence, levels=c("high", "medium", "low"))), ]
+
   ##### Keep only key columns
-  dragen.fusions <- dragen.fusions[ colnames(dragen.fusions) %in% c("geneA", "geneB", "Score", "LeftBreakpoint", "RightBreakpoint", "GeneALocation", "GeneBLocation", "NumSplitReads", "NumSoftClippedReads", "FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene", "fusions_cancer")]
-  
+  dragen.fusions <- dragen.fusions[colnames(dragen.fusions) %in% c("geneA", "geneB", "Score", "LeftBreakpoint", "RightBreakpoint", "GeneALocation", "GeneBLocation", "NumSplitReads", "NumSoftClippedReads", "FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene", "fusions_cancer")]
+
   ##### Add column to flag fusions supported by WGS data (from MANTA), if available
   dragen.fusions$geneA_dna_support <- "-"
   dragen.fusions$geneB_dna_support <- "-"
-  
+
   ##### Add results from Arriba
-  if ( runArribaChunk ) {
-    
+  if (runArribaChunk) {
     #####  Dragen's fusion format version 3.9.3
-    if ( all(c("GeneALocation", "GeneBLocation", "NumSplitReads","NumSoftClippedReads", "Score") %in% colnames(dragen.fusions)) ) {
-  
+    if (all(c("GeneALocation", "GeneBLocation", "NumSplitReads", "NumSoftClippedReads", "Score") %in% colnames(dragen.fusions))) {
       ##### Add column with Dragen fusions
-      dragen.fusions$fusion <- paste(dragen.fusions$geneA, dragen.fusions$geneB, sep="__")
+      dragen.fusions$fusion <- paste(dragen.fusions$geneA, dragen.fusions$geneB, sep = "__")
       fusions$Dragen <- c(rep("-", nrow(fusions)))
       fusions$split_reads <- fusions$split_readsA + fusions$split_readsB
       fusions$soft_clipped_reads <- c(rep("-", nrow(fusions)))
       fusions$score <- c(rep("-", nrow(fusions)))
-      
+
       ##### Re-order columns
       fusions <- fusions %>% dplyr::relocate(split_reads, .before = split_readsA)
       fusions <- fusions %>% dplyr::relocate(soft_clipped_reads, .before = confidence)
       fusions <- fusions %>% dplyr::relocate(score, .before = FGID)
-      
+
       ##### Loop through Dragen results, mark fusions detected by both tools. For those detected only by Dragen adapt results format to Arriba results
-      for ( i in 1:nrow(dragen.fusions) ) {
-        
-        if ( !is.na(match(dragen.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep="__"))) ) {
-          fusions$Dragen[ match(dragen.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep="__")) ] <- "Yes"
-          dragen.fusions[ i, ] <-  rep("-", ncol(dragen.fusions))
+      for (i in 1:nrow(dragen.fusions)) {
+        if (!is.na(match(dragen.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep = "__")))) {
+          fusions$Dragen[match(dragen.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep = "__"))] <- "Yes"
+          dragen.fusions[i, ] <- rep("-", ncol(dragen.fusions))
         } else {
-          fusions <- rbind(fusions, data.frame(geneA=dragen.fusions$geneA[i],geneB=dragen.fusions$geneB[i], breakpointA=dragen.fusions$LeftBreakpoint[i], breakpointB=dragen.fusions$RightBreakpoint[i], siteA=dragen.fusions$GeneALocation[i], siteB=dragen.fusions$GeneBLocation[i], type="-", split_reads=dragen.fusions$NumSplitReads[i], split_readsA="-", split_readsB="-", discordant_mates="-", soft_clipped_reads=dragen.fusions$NumSoftClippedReads[i], confidence="-", score=dragen.fusions$Score[i], FGID=dragen.fusions$FGID[i], reported_fusion=dragen.fusions$reported_fusion[i], reported_fusion_geneA=dragen.fusions$reported_fusion_geneA[i], reported_fusion_geneB=dragen.fusions$reported_fusion_geneB[i], effector_gene=dragen.fusions$effector_gene[i], fusions_cancer=dragen.fusions$fusions_cancer[i], geneA_dna_support="-", geneB_dna_support="-", Arriba="-", Dragen="Yes" ))
+          fusions <- rbind(fusions, data.frame(geneA = dragen.fusions$geneA[i], geneB = dragen.fusions$geneB[i], breakpointA = dragen.fusions$LeftBreakpoint[i], breakpointB = dragen.fusions$RightBreakpoint[i], siteA = dragen.fusions$GeneALocation[i], siteB = dragen.fusions$GeneBLocation[i], type = "-", split_reads = dragen.fusions$NumSplitReads[i], split_readsA = "-", split_readsB = "-", discordant_mates = "-", soft_clipped_reads = dragen.fusions$NumSoftClippedReads[i], confidence = "-", score = dragen.fusions$Score[i], FGID = dragen.fusions$FGID[i], reported_fusion = dragen.fusions$reported_fusion[i], reported_fusion_geneA = dragen.fusions$reported_fusion_geneA[i], reported_fusion_geneB = dragen.fusions$reported_fusion_geneB[i], effector_gene = dragen.fusions$effector_gene[i], fusions_cancer = dragen.fusions$fusions_cancer[i], geneA_dna_support = "-", geneB_dna_support = "-", Arriba = "-", Dragen = "Yes"))
         }
       }
-    
-    #####  Dragen's fusion format prior to version 3.9.3
+
+      #####  Dragen's fusion format prior to version 3.9.3
     } else {
-      
       ##### Add column with Dragen fusions
-      dragen.fusions$fusion <- paste(dragen.fusions$geneA, dragen.fusions$geneB, sep="__")
+      dragen.fusions$fusion <- paste(dragen.fusions$geneA, dragen.fusions$geneB, sep = "__")
       fusions$Dragen <- c(rep("-", nrow(fusions)))
       fusions$split_reads <- fusions$split_readsA + fusions$split_readsB
       fusions$score <- c(rep("-", nrow(fusions)))
-      
+
       ##### Re-order columns
       fusions <- fusions %>% dplyr::relocate(split_reads, .before = split_readsA)
       fusions <- fusions %>% dplyr::relocate(score, .before = FGID)
-        
+
       ##### Loop through Dragen results, mark fusions detected by both tools. For those detected only by Dragen adapt results format to Arriba results
-      for ( i in 1:nrow(dragen.fusions) ) {
-          
-        if ( !is.na(match(dragen.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep="__"))) ) {
-          fusions$Dragen[ match(dragen.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep="__")) ] <- "Yes"
-          dragen.fusions[ i, ] <-  rep("-", ncol(dragen.fusions))
+      for (i in 1:nrow(dragen.fusions)) {
+        if (!is.na(match(dragen.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep = "__")))) {
+          fusions$Dragen[match(dragen.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep = "__"))] <- "Yes"
+          dragen.fusions[i, ] <- rep("-", ncol(dragen.fusions))
         } else {
-          fusions <- rbind(fusions, data.frame(geneA=dragen.fusions$geneA[i],geneB=dragen.fusions$geneB[i], breakpointA=dragen.fusions$LeftBreakpoint[i], breakpointB=dragen.fusions$RightBreakpoint[i], siteA="-", siteB="-", type="-", split_reads="-", split_readsA="-", split_readsB="-", discordant_mates="-", confidence="-", score=dragen.fusions$Score[i], FGID=dragen.fusions$FGID[i], reported_fusion=dragen.fusions$reported_fusion[i], reported_fusion_geneA=dragen.fusions$reported_fusion_geneA[i], reported_fusion_geneB=dragen.fusions$reported_fusion_geneB[i], effector_gene=dragen.fusions$effector_gene[i], fusions_cancer=dragen.fusions$fusions_cancer[i], geneA_dna_support="-", geneB_dna_support="-", Arriba="-", Dragen="Yes" ))
+          fusions <- rbind(fusions, data.frame(geneA = dragen.fusions$geneA[i], geneB = dragen.fusions$geneB[i], breakpointA = dragen.fusions$LeftBreakpoint[i], breakpointB = dragen.fusions$RightBreakpoint[i], siteA = "-", siteB = "-", type = "-", split_reads = "-", split_readsA = "-", split_readsB = "-", discordant_mates = "-", confidence = "-", score = dragen.fusions$Score[i], FGID = dragen.fusions$FGID[i], reported_fusion = dragen.fusions$reported_fusion[i], reported_fusion_geneA = dragen.fusions$reported_fusion_geneA[i], reported_fusion_geneB = dragen.fusions$reported_fusion_geneB[i], effector_gene = dragen.fusions$effector_gene[i], fusions_cancer = dragen.fusions$fusions_cancer[i], geneA_dna_support = "-", geneB_dna_support = "-", Arriba = "-", Dragen = "Yes"))
         }
       }
     }
-    
-  ##### Otherwise keep only columns with info from Dragen
+
+    ##### Otherwise keep only columns with info from Dragen
   } else {
     fusions <- dragen.fusions
-    
+
     #####  Dragen's fusion format version 3.9.3
-    if ( all(c("GeneALocation", "GeneBLocation", "NumSplitReads","NumSoftClippedReads", "Score") %in% colnames(dragen.fusions)) ) {
-      
+    if (all(c("GeneALocation", "GeneBLocation", "NumSplitReads", "NumSoftClippedReads", "Score") %in% colnames(dragen.fusions))) {
       ##### Rename columns
       names(fusions) <- gsub("LeftBreakpoint", "breakpointA", names(fusions))
       names(fusions) <- gsub("RightBreakpoint", "breakpointB", names(fusions))
@@ -1986,20 +1939,18 @@ if ( nrow(dragen.fusions) > 0 ) {
       names(fusions) <- gsub("NumSplitReads", "split_reads", names(fusions))
       names(fusions) <- gsub("NumSoftClippedReads", "soft_clipped_reads", names(fusions))
       names(fusions) <- gsub("Score", "score", names(fusions))
-    
-    #####  Dragen's fusion format prior to version 3.9.3
+
+      #####  Dragen's fusion format prior to version 3.9.3
     } else {
-      
       ##### Rename columns
       names(fusions) <- gsub("LeftBreakpoint", "breakpointA", names(fusions))
       names(fusions) <- gsub("RightBreakpoint", "breakpointB", names(fusions))
       names(fusions) <- gsub("Score", "score", names(fusions))
     }
   }
-  
+
   ##### Clean the space and return output
   rm(dragen.fusion.transcripts, dragen.cancer_genes, dragen.other_genes)
-
 } else {
   runFusionChunk <- FALSE
 }
@@ -2013,135 +1964,127 @@ pizzly.fusion.candidates <- ref_genes.list[["pizzly"]]
 pizzly.cancer_genes <- data.frame()
 
 ##### Check if there are any fusions detected at all
-if ( nrow(pizzly.fusion.candidates) > 0 ) {
-    
-  for (row in 1:nrow(pizzly.fusion.candidates)){
-    if(pizzly.fusion.candidates[row,"geneA.name"] %in% rownames(ref_genes.list[["genes_cancer"]]) | pizzly.fusion.candidates[row,"geneB.name"] %in% rownames(ref_genes.list[["genes_cancer"]])) {
-      
+if (nrow(pizzly.fusion.candidates) > 0) {
+  for (row in 1:nrow(pizzly.fusion.candidates)) {
+    if (pizzly.fusion.candidates[row, "geneA.name"] %in% rownames(ref_genes.list[["genes_cancer"]]) | pizzly.fusion.candidates[row, "geneB.name"] %in% rownames(ref_genes.list[["genes_cancer"]])) {
       ##### Creating a new dataframe for extracting pizzly rows with cancer gene hits
-      pizzly.cancer_genes <- rbind(pizzly.cancer_genes, data.frame(pizzly.fusion.candidates[row,]))
+      pizzly.cancer_genes <- rbind(pizzly.cancer_genes, data.frame(pizzly.fusion.candidates[row, ]))
     }
   }
-  
+
   ##### Extracting rows from pizzly results that are not cancer genes list
-  pizzly.other_genes <- pizzly.fusion.candidates[ rownames(pizzly.fusion.candidates) %!in% rownames(pizzly.cancer_genes), ]
-    
+  pizzly.other_genes <- pizzly.fusion.candidates[rownames(pizzly.fusion.candidates) %!in% rownames(pizzly.cancer_genes), ]
+
   ##### Combing all the three above sorted dataframes
   pizzly.fusions <- rbind(pizzly.cancer_genes, pizzly.other_genes)
-    
+
   ##### Flag known fusions based on info from Cancer Biomarkers database (CGI) and FusionGDB (https://ccsm.uth.edu/FusionGDB)
   ##### Add columns for info about reported fusions
   pizzly.fusions <- cbind(pizzly.fusions, data.frame(matrix("", ncol = 5, nrow = nrow(pizzly.fusions)), stringsAsFactors = FALSE))
-  colnames(pizzly.fusions)[(ncol(pizzly.fusions)-4):ncol(pizzly.fusions)] <- c("FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene")
-    
+  colnames(pizzly.fusions)[(ncol(pizzly.fusions) - 4):ncol(pizzly.fusions)] <- c("FGID", "reported_fusion", "reported_fusion_geneA", "reported_fusion_geneB", "effector_gene")
+
   ##### Add annotations about known fusion events
   ##### Loop through all genes involved in deteced gene fusions (pizzly results) and check which are already reported
-  for ( i in 1:nrow(pizzly.fusions) ) {
+  for (i in 1:nrow(pizzly.fusions)) {
     geneA <- as.character(pizzly.fusions$geneA.name[i])
     geneB <- as.character(pizzly.fusions$geneB.name[i])
-            
+
     ##### First check if the exact reported gene pairs were detected by pizzly
-    if ( paste(geneA, geneB, sep="-") %in% trans.pairs ) {
-        
+    if (paste(geneA, geneB, sep = "-") %in% trans.pairs) {
       ##### provide fusion URL to FusionGDB
       pizzly.fusions$reported_fusion[i] <- "Yes"
-        
+
       ##### provide fusion ID from FusionGDB
-      pizzly.fusions$FGID[i] <- known_translocations$FGID[ trans.pairs %in% paste(geneA, geneB, sep="-")  ]
-        
+      pizzly.fusions$FGID[i] <- known_translocations$FGID[trans.pairs %in% paste(geneA, geneB, sep = "-")]
+
       pizzly.fusions$reported_fusion_geneA[i] <- "Yes"
       pizzly.fusions$reported_fusion_geneB[i] <- "Yes"
-        
-    } else if ( paste(geneB, geneA, sep="-") %in% trans.pairs ) {
-        
+    } else if (paste(geneB, geneA, sep = "-") %in% trans.pairs) {
       ##### provide fusion URL to FusionGDB
       pizzly.fusions$reported_fusion[i] <- "Yes"
-        
+
       ##### provide fusion ID from FusionGDB
-      pizzly.fusions$FGID[i] <- known_translocations$FGID[ trans.pairs %in% paste(geneB, geneA, sep="-")  ]
-        
+      pizzly.fusions$FGID[i] <- known_translocations$FGID[trans.pairs %in% paste(geneB, geneA, sep = "-")]
+
       pizzly.fusions$reported_fusion_geneA[i] <- "Yes"
       pizzly.fusions$reported_fusion_geneB[i] <- "Yes"
-        
-    ##### Now check if any ofthe pizzly detected fusion genes are reported
+
+      ##### Now check if any ofthe pizzly detected fusion genes are reported
     } else {
       pizzly.fusions$reported_fusion[i] <- "-"
-        
+
       ##### Check the Cancer Genome Interpreter (CGI) database first
       ##### Check pizzly genes A and genes A in reported fusions
-      if ( geneA %in% known_translocations$geneA ) {
-         pizzly.fusions$reported_fusion_geneA[i] <- "Yes"
-          
-      ##### Check pizzly genes A and genes B in reported fusions
-      } else if ( geneA %in% known_translocations$geneB ) {
+      if (geneA %in% known_translocations$geneA) {
+        pizzly.fusions$reported_fusion_geneA[i] <- "Yes"
+
+        ##### Check pizzly genes A and genes B in reported fusions
+      } else if (geneA %in% known_translocations$geneB) {
         pizzly.fusions$reported_fusion_geneA[i] <- "Yes"
       }
-        
+
       ##### Check pizzly genes B and genes A in reported fusions
-      if ( geneB %in% known_translocations$geneA ) {
+      if (geneB %in% known_translocations$geneA) {
         pizzly.fusions$reported_fusion_geneB[i] <- "Yes"
-          
-      ##### Check pizzly genes B and genes B in reported fusions
-      } else if ( geneB %in% known_translocations$geneB ) {
+
+        ##### Check pizzly genes B and genes B in reported fusions
+      } else if (geneB %in% known_translocations$geneB) {
         pizzly.fusions$reported_fusion_geneB[i] <- "Yes"
       }
-        
+
       ##### Flag if any of the genes are effector gene
-      if ( geneA %in% known_translocations$effector_gene  ) {
+      if (geneA %in% known_translocations$effector_gene) {
         pizzly.fusions$effector_gene[i] <- geneA
-      } else if ( geneB == known_translocations$effector_gene  ) {
+      } else if (geneB == known_translocations$effector_gene) {
         pizzly.fusions$effector_gene[i] <- geneB
       }
     }
   }
-    
+
   ##### Add column indicating fusions containing known cancer genes
   pizzly.fusions$fusions_cancer <- c(rep("-", nrow(pizzly.fusions)))
-  
-  if ( nrow(pizzly.cancer_genes) > 0 ) {
-    pizzly.fusions$fusions_cancer[ pizzly.fusions$geneA.name %in% pizzly.cancer_genes$geneA.name ] <- "Yes"
-    pizzly.fusions$fusions_cancer[ pizzly.fusions$geneB.name %in% pizzly.cancer_genes$geneB.name ] <- "Yes"
+
+  if (nrow(pizzly.cancer_genes) > 0) {
+    pizzly.fusions$fusions_cancer[pizzly.fusions$geneA.name %in% pizzly.cancer_genes$geneA.name] <- "Yes"
+    pizzly.fusions$fusions_cancer[pizzly.fusions$geneB.name %in% pizzly.cancer_genes$geneB.name] <- "Yes"
   }
-  
+
   ##### Re-order fusion genes based on the reported fusions column
-  pizzly.fusions <- pizzly.fusions[ order(pizzly.fusions$reported_fusion, pizzly.fusions$splitcount, pizzly.fusions$paircount, pizzly.fusions$fusions_cancer, pizzly.fusions$reported_fusion_geneA, pizzly.fusions$reported_fusion_geneB, decreasing = TRUE), ]
-  
+  pizzly.fusions <- pizzly.fusions[order(pizzly.fusions$reported_fusion, pizzly.fusions$splitcount, pizzly.fusions$paircount, pizzly.fusions$fusions_cancer, pizzly.fusions$reported_fusion_geneA, pizzly.fusions$reported_fusion_geneB, decreasing = TRUE), ]
+
   ##### Rename columns to match Arriba results
   colnames(pizzly.fusions) <- gsub("geneA.name", "geneA", colnames(pizzly.fusions))
   colnames(pizzly.fusions) <- gsub("geneB.name", "geneB", colnames(pizzly.fusions))
   colnames(pizzly.fusions) <- gsub("paircount", "discordant_mates", colnames(pizzly.fusions))
   colnames(pizzly.fusions) <- gsub("splitcount", "split_reads", colnames(pizzly.fusions))
-  pizzly.fusions <- pizzly.fusions[ colnames(pizzly.fusions) %!in% c("geneA.id", "geneB.id", "transcripts.list")]
-  
+  pizzly.fusions <- pizzly.fusions[colnames(pizzly.fusions) %!in% c("geneA.id", "geneB.id", "transcripts.list")]
+
   ##### Add results from Arriba
-  if ( runArribaChunk ) {
-    
+  if (runArribaChunk) {
     ##### Add column with pizzly fusions
-    pizzly.fusions$fusion <- paste(pizzly.fusions$geneA, pizzly.fusions$geneB, sep="__")
-    fusions$Pizzly <-  c(rep("-", nrow(fusions)))
-    
+    pizzly.fusions$fusion <- paste(pizzly.fusions$geneA, pizzly.fusions$geneB, sep = "__")
+    fusions$Pizzly <- c(rep("-", nrow(fusions)))
+
     ##### Loop through Pizzly results, mark fusions detected by both tools. For those detected only by pizzly adapt results format to Arriba results
-    for ( i in 1:nrow(pizzly.fusions) ) {
-      
-      if ( !is.na(match(pizzly.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep="__"))) ) {
-        fusions$Pizzly[ match(pizzly.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep="__")) ] <- "Yes"
-        pizzly.fusions[ i, ] <-  rep("-", ncol(pizzly.fusions))
+    for (i in 1:nrow(pizzly.fusions)) {
+      if (!is.na(match(pizzly.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep = "__")))) {
+        fusions$Pizzly[match(pizzly.fusions$fusion[i], paste(fusions$geneA, fusions$geneB, sep = "__"))] <- "Yes"
+        pizzly.fusions[i, ] <- rep("-", ncol(pizzly.fusions))
       } else {
-        fusions <- rbind(fusions, data.frame(geneA=pizzly.fusions$geneA[i],geneB=pizzly.fusions$geneB[i], breakpointA="-", breakpointB="-", siteA="-", siteB="-", type="-", split_reads=pizzly.fusions$split_reads[i], split_readsA="-", split_readsB="-", discordant_mates=pizzly.fusions$discordant_mates[i], confidence="-", FGID=pizzly.fusions$FGID[i], reported_fusion=pizzly.fusions$reported_fusion[i], reported_fusion_geneA=pizzly.fusions$reported_fusion_geneA[i], reported_fusion_geneB=pizzly.fusions$reported_fusion_geneB[i], effector_gene=pizzly.fusions$effector_gene[i], fusions_cancer=pizzly.fusions$fusions_cancer[i], geneA_dna_support="-", geneB_dna_support="-", Arriba="-", Pizzly="Yes" ))
+        fusions <- rbind(fusions, data.frame(geneA = pizzly.fusions$geneA[i], geneB = pizzly.fusions$geneB[i], breakpointA = "-", breakpointB = "-", siteA = "-", siteB = "-", type = "-", split_reads = pizzly.fusions$split_reads[i], split_readsA = "-", split_readsB = "-", discordant_mates = pizzly.fusions$discordant_mates[i], confidence = "-", FGID = pizzly.fusions$FGID[i], reported_fusion = pizzly.fusions$reported_fusion[i], reported_fusion_geneA = pizzly.fusions$reported_fusion_geneA[i], reported_fusion_geneB = pizzly.fusions$reported_fusion_geneB[i], effector_gene = pizzly.fusions$effector_gene[i], fusions_cancer = pizzly.fusions$fusions_cancer[i], geneA_dna_support = "-", geneB_dna_support = "-", Arriba = "-", Pizzly = "Yes"))
       }
     }
-  ##### Otherwise keep only columns with info from Pizzy
+    ##### Otherwise keep only columns with info from Pizzy
   } else {
     fusions <- pizzly.fusions
   }
-  
+
   ##### Add column to flag fusions supported by WGS data (from MANTA), if available
   fusions$geneA_dna_support <- "-"
   fusions$geneB_dna_support <- "-"
-  
+
   ##### Clean the space and return output
   rm(pizzly.fusions, pizzly.fusion.transcripts, pizzly.fusion.candidates, known_translocations.CGI, known_translocations.FusionGDB, pizzly.cancer_genes, pizzly.other_genes, trans.pairs)
-  
 } else {
   runFusionChunk <- FALSE
 }
@@ -2150,38 +2093,37 @@ if ( nrow(pizzly.fusion.candidates) > 0 ) {
 ```{r fusions_annot, comment = NA, message=TRUE, warning=FALSE, eval = runFusionChunk}
 ##### Annotate fusion genes
 ##### Get data to annotate fusion genes
-fusion_genes_annot <- ref_dataset.list[[dataset]][["gene_annot_all"]][ , c("ENSEMBL", "SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND") ]
+fusion_genes_annot <- ref_dataset.list[[dataset]][["gene_annot_all"]][, c("ENSEMBL", "SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND")]
 
 fusions.annot <- fusions
 fusions.annot$order <- 1:nrow(fusions.annot)
 
 ##### Get genomic info for fusions genes
-fusion_annot1 <- merge(fusion_genes_annot, fusions.annot[ , c("order","geneA")], by = 2, sort=FALSE, all.y = TRUE)
-fusion_annot1 <- fusion_annot1[ order(fusion_annot1$order), ]
-fusion_annot2 <- merge(fusion_genes_annot, fusions.annot[ , c("order","geneB")], by = 2, sort=FALSE, all.y = TRUE)
-fusion_annot2 <- fusion_annot2[ order(fusion_annot2$order), ]
+fusion_annot1 <- merge(fusion_genes_annot, fusions.annot[, c("order", "geneA")], by = 2, sort = FALSE, all.y = TRUE)
+fusion_annot1 <- fusion_annot1[order(fusion_annot1$order), ]
+fusion_annot2 <- merge(fusion_genes_annot, fusions.annot[, c("order", "geneB")], by = 2, sort = FALSE, all.y = TRUE)
+fusion_annot2 <- fusion_annot2[order(fusion_annot2$order), ]
 
 ##### Dragen + Arriba
-if ( runDragenFusionChunk && runArribaChunk ) {
-  fusion_annot <- cbind(fusion_annot1, fusion_annot2, fusions.annot[, c("score", "breakpointA", "breakpointB", "discordant_mates", "split_reads",  "split_readsA", "split_readsB", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB")])
-  
-##### Arriba / Arriba + Pizzly
-} else if ( runArribaChunk ) {
+if (runDragenFusionChunk && runArribaChunk) {
+  fusion_annot <- cbind(fusion_annot1, fusion_annot2, fusions.annot[, c("score", "breakpointA", "breakpointB", "discordant_mates", "split_reads", "split_readsA", "split_readsB", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB")])
+
+  ##### Arriba / Arriba + Pizzly
+} else if (runArribaChunk) {
   fusion_annot <- cbind(fusion_annot1, fusion_annot2, fusions.annot[, c("breakpointA", "breakpointB", "discordant_mates", "split_reads", "split_readsA", "split_readsB", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB")])
-  
-##### Dragen only
-} else if ( runDragenFusionChunk ) {
-  
+
+  ##### Dragen only
+} else if (runDragenFusionChunk) {
   #####  Dragen's fusion format version 3.9.3
-  if ( all(c("GeneALocation", "GeneBLocation", "NumSplitReads","NumSoftClippedReads", "Score") %in% colnames(dragen.fusions)) ) {
+  if (all(c("GeneALocation", "GeneBLocation", "NumSplitReads", "NumSoftClippedReads", "Score") %in% colnames(dragen.fusions))) {
     fusion_annot <- cbind(fusion_annot1, fusion_annot2, fusions.annot[, c("score", "breakpointA", "breakpointB", "split_reads", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB")])
-    
-  #####  Dragen's fusion format prior to version 3.9.3
+
+    #####  Dragen's fusion format prior to version 3.9.3
   } else {
     fusion_annot <- cbind(fusion_annot1, fusion_annot2, fusions.annot[, c("score", "breakpointA", "breakpointB", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB")])
   }
-  
-##### Pizzly only
+
+  ##### Pizzly only
 } else {
   fusion_annot <- cbind(fusion_annot1, fusion_annot2, fusions.annot[, c("split_reads", "discordant_mates", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB")])
 }
@@ -2190,7 +2132,7 @@ if ( runDragenFusionChunk && runArribaChunk ) {
 fusion_annot$geneA_dna_support <- "-"
 fusion_annot$geneB_dna_support <- "-"
 
-colnames(fusion_annot) = make.names(colnames(fusion_annot), unique=TRUE)
+colnames(fusion_annot) <- make.names(colnames(fusion_annot), unique = TRUE)
 
 ##### Remove entries with missing annotation
 fusion_annot <- fusion_annot[complete.cases(fusion_annot), ]
@@ -2206,17 +2148,15 @@ manta_sv <- ref_genes.list[["manta"]]
 manta_sv$"Fusion genes" <- manta_sv$Gene
 
 i <- 1
-while ( i <= nrow(manta_sv) ) {
-  if ( length(strsplit(manta_sv$Gene[i], split='&', fixed=TRUE)[[1]]) > 1 ) {
-     
+while (i <= nrow(manta_sv)) {
+  if (length(strsplit(manta_sv$Gene[i], split = "&", fixed = TRUE)[[1]]) > 1) {
     ##### Insert new row for events involving two genes
     manta_sv <- tibble::add_row(manta_sv, .after = i)
-    manta_sv[i+1, ] <- manta_sv[i, ]
-    manta_sv$Gene[i] <- strsplit(manta_sv$Gene[i], split='&', fixed=TRUE)[[1]][1]
-    manta_sv$Gene[i+1] <- strsplit(manta_sv$Gene[i+1], split='&', fixed=TRUE)[[1]][2]
-    
+    manta_sv[i + 1, ] <- manta_sv[i, ]
+    manta_sv$Gene[i] <- strsplit(manta_sv$Gene[i], split = "&", fixed = TRUE)[[1]][1]
+    manta_sv$Gene[i + 1] <- strsplit(manta_sv$Gene[i + 1], split = "&", fixed = TRUE)[[1]][2]
+
     i <- i + 2
-    
   } else {
     manta_sv$"Fusion genes"[i] <- ""
     i <- i + 1
@@ -2225,29 +2165,29 @@ while ( i <= nrow(manta_sv) ) {
 
 ##### Compare fusion genes called by PIZZLy and MANTA
 ##### First limit MANTA output to fusions only
-if ( runFusionChunk ) {
-  manta_fusions <- unique(manta_sv[ grep("&", manta_sv$"Fusion genes"),  ]$Gene)
-  manta_fusions <- manta_fusions[ manta_fusions %in% unique(c(as.vector(fusions$geneA), as.vector(fusions$geneB))) ]
-    
+if (runFusionChunk) {
+  manta_fusions <- unique(manta_sv[grep("&", manta_sv$"Fusion genes"), ]$Gene)
+  manta_fusions <- manta_fusions[manta_fusions %in% unique(c(as.vector(fusions$geneA), as.vector(fusions$geneB)))]
+
   ##### Flag fusions that were also reported in MANTA
-  if ( length(manta_fusions) > 0 ) {
-    fusions$geneA_dna_support[ sort( match( manta_fusions , fusions$geneA ), na.last = NA ) ] <- "Yes"
-    fusions$geneB_dna_support[ sort( match( manta_fusions , fusions$geneB ), na.last = NA ) ] <- "Yes"
-      
-    fusion_annot$geneA_dna_support[ sort( match( manta_fusions , fusion_annot$SYMBOL ), na.last = NA ) ] <- "Yes"
-    fusion_annot$geneB_dna_support[ sort( match( manta_fusions , fusion_annot$SYMBOL.1 ), na.last = NA ) ] <- "Yes"
-  
+  if (length(manta_fusions) > 0) {
+    fusions$geneA_dna_support[sort(match(manta_fusions, fusions$geneA), na.last = NA)] <- "Yes"
+    fusions$geneB_dna_support[sort(match(manta_fusions, fusions$geneB), na.last = NA)] <- "Yes"
+
+    fusion_annot$geneA_dna_support[sort(match(manta_fusions, fusion_annot$SYMBOL), na.last = NA)] <- "Yes"
+    fusion_annot$geneB_dna_support[sort(match(manta_fusions, fusion_annot$SYMBOL.1), na.last = NA)] <- "Yes"
+
     ##### Re-order fusion dataframe with MANTA supporting fusions on top
-    if ( runArribaChunk ) {
+    if (runArribaChunk) {
       idx <- order(fusions$geneA_dna_support, fusions$geneB_dna_support, fusions$Arriba, fusions$reported_fusion, decreasing = TRUE)
     } else {
       idx <- order(fusions$geneA_dna_support, fusions$geneB_dna_support, fusions$reported_fusion, decreasing = TRUE)
     }
-    
-    fusions <- fusions[ idx, ]
-    fusion_annot <- fusion_annot[ idx, ]
+
+    fusions <- fusions[idx, ]
+    fusion_annot <- fusion_annot[idx, ]
   }
-  
+
   ##### Remove entries with missing annotation
   fusion_annot <- fusion_annot[complete.cases(fusion_annot), ]
 }
@@ -2260,31 +2200,30 @@ rm(manta_fusions)
 ##### Filter out fusions that are with < 2 split reads and < 2 pair reads and are not supported by genomic data, are not reported and don't involve cancer genes
 
 ##### Dragen + Arriba
-if ( runDragenFusionChunk && runArribaChunk ) {
-  fusions <- fusions %>% dplyr::filter( split_reads > 1 | discordant_mates > 1 | score > 0 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
-  fusion_annot <- fusion_annot %>% dplyr::filter( split_reads > 1 | discordant_mates > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
+if (runDragenFusionChunk && runArribaChunk) {
+  fusions <- fusions %>% dplyr::filter(split_reads > 1 | discordant_mates > 1 | score > 0 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
+  fusion_annot <- fusion_annot %>% dplyr::filter(split_reads > 1 | discordant_mates > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
 
   ##### Arriba / Arriba + Pizzly
-} else if ( runArribaChunk ) {
-  fusions <- fusions %>% dplyr::filter( split_reads > 1 | discordant_mates > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
-  fusion_annot <- fusion_annot %>% dplyr::filter( split_reads > 1 | discordant_mates > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
-  
-##### Dragen only
-} else if ( runDragenFusionChunk ) {
-  
+} else if (runArribaChunk) {
+  fusions <- fusions %>% dplyr::filter(split_reads > 1 | discordant_mates > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
+  fusion_annot <- fusion_annot %>% dplyr::filter(split_reads > 1 | discordant_mates > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
+
+  ##### Dragen only
+} else if (runDragenFusionChunk) {
   ##### For Dragen , this filtering is not changing the results. We'll review the "Score" value again once we start to regularly produce the RNAsum report for Dragen results
   #####  Dragen's fusion format version 3.9.3
-  if ( all(c("GeneALocation", "GeneBLocation", "NumSplitReads","NumSoftClippedReads", "Score") %in% colnames(fusions)) ) {
-    fusions <- fusions %>% dplyr::filter( split_reads > 1 | score > 0 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
-    fusion_annot <- fusion_annot %>% dplyr::filter( score > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
-  
-  #####  Dragen's fusion format prior to version 3.9.3
+  if (all(c("GeneALocation", "GeneBLocation", "NumSplitReads", "NumSoftClippedReads", "Score") %in% colnames(fusions))) {
+    fusions <- fusions %>% dplyr::filter(split_reads > 1 | score > 0 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
+    fusion_annot <- fusion_annot %>% dplyr::filter(score > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
+
+    #####  Dragen's fusion format prior to version 3.9.3
   } else {
-    fusions <- fusions %>% dplyr::filter( score > 0 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
-    fusion_annot <- fusion_annot %>% dplyr::filter( score > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
+    fusions <- fusions %>% dplyr::filter(score > 0 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
+    fusion_annot <- fusion_annot %>% dplyr::filter(score > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
   }
-  
-##### Pizzly only
+
+  ##### Pizzly only
 } else {
   fusions <- fusions %>% dplyr::filter(split_reads > 1 | discordant_mates > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
   fusion_annot <- fusion_annot %>% dplyr::filter(split_reads > 1 | discordant_mates > 1 | geneA_dna_support != "-" | geneB_dna_support != "-" | reported_fusion != "-" | fusions_cancer != "-")
@@ -2294,35 +2233,34 @@ if ( runDragenFusionChunk && runArribaChunk ) {
 ```{r fusions_circos, comment = NA, message=FALSE, warning=FALSE, eval = runFusionChunk}
 ##### Indicate which fusions have genomic coordinates and can be presented on circos plot
 ##### Take into account only reported fusions or those with both genes genes supported by DNA
-if ( runSVsChunk ) {
-  fusion_annot_top <- fusion_annot[ fusion_annot$reported_fusion == "Yes" | fusion_annot$geneA_dna_support == "Yes" | fusion_annot$geneB_dna_support == "Yes" , ]
+if (runSVsChunk) {
+  fusion_annot_top <- fusion_annot[fusion_annot$reported_fusion == "Yes" | fusion_annot$geneA_dna_support == "Yes" | fusion_annot$geneB_dna_support == "Yes", ]
 } else {
-  fusion_annot_top <- fusion_annot[ fusion_annot$reported_fusion == "Yes" , ]
+  fusion_annot_top <- fusion_annot[fusion_annot$reported_fusion == "Yes", ]
 }
 
 fusions$circos <- "-"
-fusions$circos[ paste(fusions$geneA, fusions$geneB, sep="-") %in% paste(fusion_annot_top$SYMBOL, fusion_annot_top$SYMBOL.1, sep="-") ] <- "Yes"
+fusions$circos[paste(fusions$geneA, fusions$geneB, sep = "-") %in% paste(fusion_annot_top$SYMBOL, fusion_annot_top$SYMBOL.1, sep = "-")] <- "Yes"
 ```
 
 ```{r immunogram_table_prep, comment = NA, message=FALSE, warning=FALSE, eval = params$immunogram}
 ##### Extract data for Immunogram genes
 data <- ref_dataset.list[[dataset]][["data_to_report"]]
-data <- data[ rownames(data) %in% ref_genes.list[["genes_immune"]]$immunogram$SYMBOL, ]
+data <- data[rownames(data) %in% ref_genes.list[["genes_immune"]]$immunogram$SYMBOL, ]
 
 ##### Create lists with caulcuation results for each individual Cancer-Immunity Cycle (CIC) step
 CIC.list <- vector("list", length(unique(ref_genes.list[["genes_immune"]]$immunogram$CIC)))
 names(CIC.list) <- unique(ref_genes.list[["genes_immune"]]$immunogram$CIC)
-  
+
 ##### Calculate average expression for each Cancer-Immunity Cycle (CIC) step
-for ( cic_step in unique(ref_genes.list[["genes_immune"]]$immunogram$CIC) ) {
-  
-  genes <- ref_genes.list[["genes_immune"]]$immunogram$SYMBOL[ ref_genes.list[["genes_immune"]]$immunogram$CIC %in% cic_step ]
-  data.sub <- data[ rownames(data) %in% genes, ]
+for (cic_step in unique(ref_genes.list[["genes_immune"]]$immunogram$CIC)) {
+  genes <- ref_genes.list[["genes_immune"]]$immunogram$SYMBOL[ref_genes.list[["genes_immune"]]$immunogram$CIC %in% cic_step]
+  data.sub <- data[rownames(data) %in% genes, ]
   CIC.list[[cic_step]] <- colMeans(data.sub)
 }
 
 ##### Conver the list into dataframe
-ref_genes.list[["genes_immune"]]$immunogram.df <- t(data.frame(matrix(unlist(CIC.list), nrow=length(CIC.list), byrow=T),stringsAsFactors=FALSE))
+ref_genes.list[["genes_immune"]]$immunogram.df <- t(data.frame(matrix(unlist(CIC.list), nrow = length(CIC.list), byrow = T), stringsAsFactors = FALSE))
 colnames(ref_genes.list[["genes_immune"]]$immunogram.df) <- names(CIC.list)
 rownames(ref_genes.list[["genes_immune"]]$immunogram.df) <- colnames(data.sub)
 ```
@@ -2330,34 +2268,33 @@ rownames(ref_genes.list[["genes_immune"]]$immunogram.df) <- colnames(data.sub)
 ```{r ref_cohorts_summary, comment = NA, message=FALSE, warning=FALSE}
 ##### Summarise the reference cohorts samples
 target <- ref_dataset.list[[dataset]][["sample_annot"]]
-ref_ext_cancer <- table(target$Target)[names(table(target$Target))==ext_cancer_group]
-ref_int_cancer <- table(target$Target)[names(table(target$Target))==int_cancer_group]
+ref_ext_cancer <- table(target$Target)[names(table(target$Target)) == ext_cancer_group]
+ref_int_cancer <- table(target$Target)[names(table(target$Target)) == int_cancer_group]
 
-if ( !is.null(add_cancer_group) ) {
-  ref_ext_cancer <- table(target$Target)[names(table(target$Target))==c(ext_cancer_group)] +  table(target$Target)[names(table(target$Target))==c(add_cancer_group)]
+if (!is.null(add_cancer_group)) {
+  ref_ext_cancer <- table(target$Target)[names(table(target$Target)) == c(ext_cancer_group)] + table(target$Target)[names(table(target$Target)) == c(add_cancer_group)]
 }
 ```
 
 ```{r goi_summary_update, comment = NA, message=FALSE, warning=FALSE}
 ##### Update altered genes in ...
-##### ...gene fusion section: Include only those which are DNA-supported (see Structural variants section) or reported in FusionGDB 
-if ( runFusionChunk ) {
-  ref_genes.list[["summary"]]$Fusion <- fusions[ fusions$reported_fusion == "Yes" | fusions$geneA_dna_support == "Yes" | fusions$geneB_dna_support == "Yes" , ]
+##### ...gene fusion section: Include only those which are DNA-supported (see Structural variants section) or reported in FusionGDB
+if (runFusionChunk) {
+  ref_genes.list[["summary"]]$Fusion <- fusions[fusions$reported_fusion == "Yes" | fusions$geneA_dna_support == "Yes" | fusions$geneB_dna_support == "Yes", ]
   ref_genes.list[["summary"]]$Fusion <- unique(c(as.character(ref_genes.list[["summary"]]$Fusion$geneA), as.character(ref_genes.list[["summary"]]$Fusion$geneB)))
 } else {
   ref_genes.list[["summary"]]$Fusion <- NULL
 }
 
 ##### ...copy-number (CN) section: include only genes with CN values > 3 or < 0.5
-if ( runPurpleChunk ) {
-  
+if (runPurpleChunk) {
   #### Keep only genes with user-define CN values
   ref_genes.list[["summary"]]$CN <- ref_dataset.list[[dataset]][["expr_mut_cn_data"]]
-  ref_genes.list[["summary"]]$CN <- as.character(ref_genes.list[["summary"]]$CN[ ref_genes.list[["summary"]]$CN$CN <= cn_bottom | ref_genes.list[["summary"]]$CN$CN >= cn_top,  ]$Gene)
+  ref_genes.list[["summary"]]$CN <- as.character(ref_genes.list[["summary"]]$CN[ref_genes.list[["summary"]]$CN$CN <= cn_bottom | ref_genes.list[["summary"]]$CN$CN >= cn_top, ]$Gene)
 }
 
 ##### ...immune markers section: include only genes with available annotation
-if ( params$immunogram ) {
+if (params$immunogram) {
   ref_genes.list[["summary"]]$Immune <- unique(c(ref_genes.list[["genes_immune"]]$immunogram$SYMBOL, ref_genes.list[["genes_immune"]]$immune_markers$SYMBOL))
 } else {
   ref_genes.list[["summary"]]$Immune <- unique(ref_genes.list[["genes_immune"]]$immune_markers$SYMBOL)
@@ -2376,92 +2313,92 @@ alt_genes.all.list$Cancer <- NULL
 ##### Note all altered genes
 alt_genes.all <- sort(table(unlist(alt_genes.all.list)), decreasing = TRUE)
 
-for ( alt in names(alt_genes.all.list) ) {
-
+for (alt in names(alt_genes.all.list)) {
   ##### Add only alteration type which has at least one alteration detected
-  if ( length(alt_genes.all[ names(alt_genes.all) %in% alt_genes.all.list[[ alt ]] ])  > 0 ) {
-    alt_genes.all.list[[ alt ]] <- alt_genes.all[ names(alt_genes.all) %in% alt_genes.all.list[[ alt ]] ]
+  if (length(alt_genes.all[names(alt_genes.all) %in% alt_genes.all.list[[alt]]]) > 0) {
+    alt_genes.all.list[[alt]] <- alt_genes.all[names(alt_genes.all) %in% alt_genes.all.list[[alt]]]
   } else {
-    alt_genes.all.list[[ alt ]] <- NULL
+    alt_genes.all.list[[alt]] <- NULL
   }
 }
 
-sunburst.all.df <- data.frame(ids = names(alt_genes.all.list),
+sunburst.all.df <- data.frame(
+  ids = names(alt_genes.all.list),
   labels = names(alt_genes.all.list),
   parents = rep("", length(alt_genes.all.list)),
-  values = as.numeric(lengths(alt_genes.all.list))/100,
+  values = as.numeric(lengths(alt_genes.all.list)) / 100,
   stringsAsFactors = FALSE
 )
 
-for ( alt in names(alt_genes.all.list) ) {
-  
+for (alt in names(alt_genes.all.list)) {
   ##### Add only alteration type which has at least one alteration detected
-  if ( length(alt_genes.all[ names(alt_genes.all) %in% names(alt_genes.all.list[[ alt ]]) ])  > 0 ) {
-      
-    sunburst.all.df <- rbind( sunburst.all.df , data.frame(ids = paste( alt, names(alt_genes.all.list[[ alt ]]), sep = " - "), 
-          labels = paste0("\t\t", names(alt_genes.all.list[[ alt ]]), "\t\t"),
-          parents = rep( alt , length(alt_genes.all.list[[ alt ]])),
-          values = as.numeric(alt_genes.all.list[[ alt ]])
-          ) )
+  if (length(alt_genes.all[names(alt_genes.all) %in% names(alt_genes.all.list[[alt]])]) > 0) {
+    sunburst.all.df <- rbind(sunburst.all.df, data.frame(
+      ids = paste(alt, names(alt_genes.all.list[[alt]]), sep = " - "),
+      labels = paste0("\t\t", names(alt_genes.all.list[[alt]]), "\t\t"),
+      parents = rep(alt, length(alt_genes.all.list[[alt]])),
+      values = as.numeric(alt_genes.all.list[[alt]])
+    ))
   }
 }
 
 sunburst_plot <- NULL
-sunburst_plot[[1]] <- plot_ly(sunburst.all.df, ids = ~ids, labels = ~labels, parents = ~parents, values = ~values, type = 'sunburst', width = 600, height = 600)
+sunburst_plot[[1]] <- plot_ly(sunburst.all.df, ids = ~ids, labels = ~labels, parents = ~parents, values = ~values, type = "sunburst", width = 600, height = 600)
 
 ##### Now include only Identify genes that appear in more then two lists
 alt_genes.list <- alt_genes.all.list
-alt_genes <- alt_genes.all[ alt_genes.all > 1 ]
+alt_genes <- alt_genes.all[alt_genes.all > 1]
 
-for ( alt in names(alt_genes.list) ) {
-
+for (alt in names(alt_genes.list)) {
   ##### Add only alteration type which has at least one alteration detected
-  if ( length(alt_genes[ names(alt_genes) %in% names(alt_genes.list[[ alt ]]) ])  > 0 ) {
-    alt_genes.list[[ alt ]] <- alt_genes[ names(alt_genes) %in% names(alt_genes.list[[ alt ]]) ]
+  if (length(alt_genes[names(alt_genes) %in% names(alt_genes.list[[alt]])]) > 0) {
+    alt_genes.list[[alt]] <- alt_genes[names(alt_genes) %in% names(alt_genes.list[[alt]])]
   } else {
-    alt_genes.list[[ alt ]] <- NULL
+    alt_genes.list[[alt]] <- NULL
   }
 }
-  
-sunburst.df <- data.frame(ids = names(alt_genes.list),
+
+sunburst.df <- data.frame(
+  ids = names(alt_genes.list),
   labels = names(alt_genes.list),
   parents = rep("", length(alt_genes.list)),
-  values = as.numeric(lengths(alt_genes.list))/100,
+  values = as.numeric(lengths(alt_genes.list)) / 100,
   stringsAsFactors = FALSE
 )
-  
-for ( alt in names(alt_genes.list) ) {
-  sunburst.df <- rbind( sunburst.df , data.frame(ids = paste( alt, names(alt_genes.list[[ alt ]]), sep = " - "), 
-        labels = paste0("\t\t", names(alt_genes.list[[ alt ]]), "\t\t"),
-        parents = rep( alt , length(alt_genes.list[[ alt ]])),
-        values = as.numeric(alt_genes.list[[ alt ]])
-        ) )
+
+for (alt in names(alt_genes.list)) {
+  sunburst.df <- rbind(sunburst.df, data.frame(
+    ids = paste(alt, names(alt_genes.list[[alt]]), sep = " - "),
+    labels = paste0("\t\t", names(alt_genes.list[[alt]]), "\t\t"),
+    parents = rep(alt, length(alt_genes.list[[alt]])),
+    values = as.numeric(alt_genes.list[[alt]])
+  ))
 }
 
-if ( nrow(sunburst.df) > 0 ) {
-  sunburst_plot[[2]] <- plot_ly(sunburst.df, ids = ~ids, labels = ~labels, parents = ~parents, values = ~values, type = 'sunburst', width = 600, height = 600)
+if (nrow(sunburst.df) > 0) {
+  sunburst_plot[[2]] <- plot_ly(sunburst.df, ids = ~ids, labels = ~labels, parents = ~parents, values = ~values, type = "sunburst", width = 600, height = 600)
 } else {
   sunburst_plot[[2]] <- NA
 }
 
 ##### Create directory for the plots
 summaryPlotsDir <- paste(results_dir, "summaryPlots", sep = "/")
-if ( !file.exists(summaryPlotsDir) ) {
-  dir.create(summaryPlotsDir, recursive=TRUE)
+if (!file.exists(summaryPlotsDir)) {
+  dir.create(summaryPlotsDir, recursive = TRUE)
 }
-  
+
 ##### Save interactive plot as html file
 saveWidgetFix(sunburst_plot[[1]], file = paste(summaryPlotsDir, "sunburst_plot_all.html", sep = "/"))
 
-if ( !is.na(sunburst_plot[[2]]) ) {
+if (!is.na(sunburst_plot[[2]])) {
   saveWidgetFix(sunburst_plot[[2]], file = paste(summaryPlotsDir, "sunburst_plot.html", sep = "/"))
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 
 ##### Clean the space
 rm(sunburst.all.df, sunburst.df)
@@ -2473,37 +2410,36 @@ rm(sunburst.all.df, sunburst.df)
 genes.list <- names(alt_genes.all)
 summary_table.list <- vector("list", length(genes.list))
 names(summary_table.list) <- genes.list
-  
+
 ##### Go through all alterated genes and note the alterations types
-for ( gene in names(alt_genes.all) ) {
-  for ( alt in names(alt_genes.all.list) ) {
-    if ( gene %in% names(alt_genes.all.list[[ alt ]])  ) {
-      summary_table.list[[ gene ]] <- c( summary_table.list[[ gene ]], "Yes" )
+for (gene in names(alt_genes.all)) {
+  for (alt in names(alt_genes.all.list)) {
+    if (gene %in% names(alt_genes.all.list[[alt]])) {
+      summary_table.list[[gene]] <- c(summary_table.list[[gene]], "Yes")
     } else {
-      summary_table.list[[ gene ]] <- c( summary_table.list[[ gene ]], "-" )
+      summary_table.list[[gene]] <- c(summary_table.list[[gene]], "-")
     }
   }
-  
+
   ##### Add links to external resources
   ##### Provide link to VICC meta-knowledgebase ( https://search.cancervariants.org )
-  summary_table.list[[ gene ]] <- c( summary_table.list[[ gene ]], paste0("<a href='https://search.cancervariants.org/#", gene, "' target='_blank'>VICC</a>"))
-      
+  summary_table.list[[gene]] <- c(summary_table.list[[gene]], paste0("<a href='https://search.cancervariants.org/#", gene, "' target='_blank'>VICC</a>"))
+
   ##### Provide link to OncoKB
-  if ( gene %in% rownames(ref_genes.list[["genes_oncokb"]]) ) {
-    if ( ref_genes.list[["genes_oncokb"]][  gene, "OncoKB"] == "Yes" ) {
-          
-      summary_table.list[[ gene ]][ length(summary_table.list[[ gene ]])] <- paste( summary_table.list[[ gene ]][ length(summary_table.list[[ gene ]])] , paste0("<a href='http://oncokb.org/#/gene/", gene, "' target='_blank'>OncoKB</a>"), sep = ", ")
+  if (gene %in% rownames(ref_genes.list[["genes_oncokb"]])) {
+    if (ref_genes.list[["genes_oncokb"]][gene, "OncoKB"] == "Yes") {
+      summary_table.list[[gene]][length(summary_table.list[[gene]])] <- paste(summary_table.list[[gene]][length(summary_table.list[[gene]])], paste0("<a href='http://oncokb.org/#/gene/", gene, "' target='_blank'>OncoKB</a>"), sep = ", ")
     }
   }
-      
+
   ##### Provide link to CIViC database druggable genes ( https://civicdb.org )
-  if ( gene %in% caner_genes_annot.list[["civic_clin_evid"]]$gene ) {
-    summary_table.list[[ gene ]][ length(summary_table.list[[ gene ]])] <- paste( summary_table.list[[ gene ]][ length(summary_table.list[[ gene ]])] , paste0("<a href='", unique(caner_genes_annot.list[["civic_clin_evid"]][ caner_genes_annot.list[["civic_clin_evid"]]$gene == gene , "gene_civic_url"]), "' target='_blank'>CIViC</a>"), sep = ", ")
+  if (gene %in% caner_genes_annot.list[["civic_clin_evid"]]$gene) {
+    summary_table.list[[gene]][length(summary_table.list[[gene]])] <- paste(summary_table.list[[gene]][length(summary_table.list[[gene]])], paste0("<a href='", unique(caner_genes_annot.list[["civic_clin_evid"]][caner_genes_annot.list[["civic_clin_evid"]]$gene == gene, "gene_civic_url"]), "' target='_blank'>CIViC</a>"), sep = ", ")
   }
 }
 
 ##### Convert the list into data frame
-summary_table.df <- data.frame(matrix(unlist(summary_table.list), nrow=length(summary_table.list), byrow=T),stringsAsFactors=FALSE)
+summary_table.df <- data.frame(matrix(unlist(summary_table.list), nrow = length(summary_table.list), byrow = T), stringsAsFactors = FALSE)
 
 ##### Add gene names and number of section in which individual genes are reported
 summary_table.df <- cbind(names(summary_table.list), summary_table.df)
@@ -2565,7 +2501,7 @@ Plot(s) below present `r params$transform` data distribution `r if ( params$filt
 ```{r data_transformation_display, fig.width = 12, fig.height = 5, thumb = list(width = 15, height = 15) }
 data_transformation_nonfiltered
 
-if ( params$filter ) {
+if (params$filter) {
   data_transformation_filtered
 }
 ```
@@ -2579,7 +2515,7 @@ Box-plots below present `r params$transform` data for individual samples, colour
 ```{r data_normalisation_display, fig.width = 12, fig.height = 9, thumb = list(width = 15, height = 15) }
 data_nonnormalised
 
-if ( params$norm != "none" ) {
+if (params$norm != "none") {
   data_normalised
 }
 ```
@@ -2598,14 +2534,14 @@ Principal component analysis (PCA) was performed to reduce the dimensionality of
 ref_dataset.list[[dataset]][["pca_combined_data_processed"]][[2]]
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 ```{r pca_batch_effect_corrected_display, comment = NA, message=FALSE, warning=FALSE, eval=params$batch_rm, fig.width = 8, fig.height = 8 }
 ref_dataset.list[[dataset]][["pca_batch_effect_corrected"]][[2]]
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 * **Scree-plot**
@@ -2616,7 +2552,7 @@ if(!is.null(dev.list())) invisible(dev.off())
 ref_dataset.list[[dataset]][["pca_combined_data_processed"]][[3]]
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 `r if ( params$batch_rm ) { cat("* After batch-effects correction") } else { cat(" ") }`
@@ -2625,7 +2561,7 @@ if(!is.null(dev.list())) invisible(dev.off())
 ref_dataset.list[[dataset]][["pca_batch_effect_corrected"]][[3]]
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 * **RLE plot**
@@ -2635,7 +2571,7 @@ The relative log expression (RLE) plot is a useful diagnostic tool to visualise 
 ```{r rle_display, comment = NA, message=FALSE, warning=FALSE, fig.width = 12, fig.height = 9, thumb = list(width = 15, height = 15)}
 ref_dataset.list[[dataset]][["rle_combined_data_processed"]]
 
-if ( params$norm != "none" ) {
+if (params$norm != "none") {
   ref_dataset.list[[dataset]][["rle_batch_effect_corrected"]]
 }
 ```
@@ -2671,26 +2607,26 @@ mysql_populate <- paste0(mysql_populate, "Findings summary")
 mysql_populate_update <- paste0(mysql_populate_update, "Findings summary")
 
 ##### Present per-alteration findings summary sunburst plot for all altered genes
-if ( !is.na(sunburst_plot[[2]]) ) {
+if (!is.na(sunburst_plot[[2]])) {
   sunburst_plot[[2]]
 } else {
   sunburst_plot[[1]]
 }
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 `r if ( !is.na(sunburst_plot[[2]]) ) { c("<details>\n<summary>Show all altered genes</summary>") }`
 
 ```{r findings_summary_all_plot, comment = NA, message=FALSE, warning=FALSE, fig.width = 8, fig.height = 6 }
 ##### Present per-alteration findings summary sunburst plot for altered genes listed in at least two report sections
-if ( !is.na(sunburst_plot[[2]]) ) {
+if (!is.na(sunburst_plot[[2]])) {
   sunburst_plot[[1]]
 }
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 `r if ( !is.na(sunburst_plot[[2]]) ) { c("</details>") }`
@@ -2709,21 +2645,23 @@ Table summarising **all altered genes** listed across following report sections:
 
 ```{r findings_summary_table, comment = NA, message=FALSE, warning=FALSE }
 ##### Present per-gene findings summary table
-findings.summary <- DT::datatable( data = summary_table.df, filter="none", rownames = FALSE, extensions = c('Buttons','Scroller'), options = list(pageLength = 10, dom = 'Bfrltip', buttons = c('excel', 'csv', 'pdf','copy','colvis'), scrollX = TRUE, deferRender = TRUE, scrollY = "333px", scroller = TRUE), width = 800, height = 455, caption = htmltools::tags$caption( style = 'caption-side: top; text-align: left; color:grey; font-size:100%'), escape = FALSE) %>%
-      DT::formatStyle( columns = colnames(summary_table.df), `font-size` = '12px', 'text-align' = 'center' ) %>%
-      ##### Colour cells according to evidence level and trust rating
-      DT::formatStyle(columns = colnames(summary_table.df)[c(2:ncol(summary_table.df)-2)], 
-                      backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "black")), color = DT::styleEqual(c("-", "Yes"), c("black", "white")))
+findings.summary <- DT::datatable(data = summary_table.df, filter = "none", rownames = FALSE, extensions = c("Buttons", "Scroller"), options = list(pageLength = 10, dom = "Bfrltip", buttons = c("excel", "csv", "pdf", "copy", "colvis"), scrollX = TRUE, deferRender = TRUE, scrollY = "333px", scroller = TRUE), width = 800, height = 455, caption = htmltools::tags$caption(style = "caption-side: top; text-align: left; color:grey; font-size:100%"), escape = FALSE) %>%
+  DT::formatStyle(columns = colnames(summary_table.df), `font-size` = "12px", "text-align" = "center") %>%
+  ##### Colour cells according to evidence level and trust rating
+  DT::formatStyle(
+    columns = colnames(summary_table.df)[c(2:ncol(summary_table.df) - 2)],
+    backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "black")), color = DT::styleEqual(c("-", "Yes"), c("black", "white"))
+  )
 
 findings.summary
 
 ##### Create directory for tables
 summaryTableDir <- paste(results_dir, "summaryTables", sep = "/")
-if ( !file.exists(summaryTableDir) ) {
-    dir.create(summaryTableDir, recursive=TRUE)
+if (!file.exists(summaryTableDir)) {
+  dir.create(summaryTableDir, recursive = TRUE)
 }
 
-saveWidgetFix(widget=findings.summary, file=paste(summaryTableDir, "findings.summary.html", sep = "/"), selfcontained=TRUE)
+saveWidgetFix(widget = findings.summary, file = paste(summaryTableDir, "findings.summary.html", sep = "/"), selfcontained = TRUE)
 
 ##### Clean the space
 rm(summary_table.df, findings.summary, sunburst_plot)
@@ -2756,11 +2694,11 @@ data <- ref_dataset.list[[dataset]][["data_to_report"]]
 genes <- ref_genes.list[["summary"]]$Mutated
 
 ##### Deal with no genes or when more than 10 genes are of interest
-if ( length(genes) == 0 ) {
+if (length(genes) == 0) {
   genes <- NULL
   limit_genes <- FALSE
   genes_no <- 0
-} else if ( length(genes) > params$top_genes ) {
+} else if (length(genes) > params$top_genes) {
   limit_genes <- TRUE
   genes_no <- params$top_genes
 } else {
@@ -2768,15 +2706,15 @@ if ( length(genes) == 0 ) {
   genes_no <- length(genes)
 }
 
-mut_genes.expr.perc <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+mut_genes.expr.perc <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 
 ##### Present the expression summary table
 mut_genes.expr.perc[[1]]
 
 ##### Save the expression table as html file
 ##### Create directory for tables
-if ( params$save_tables ) {
-  saveWidgetFix(widget=mut_genes.expr.perc[[1]], file=paste(exprTableDir, "mut_genes.expr.perc.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = mut_genes.expr.perc[[1]], file = paste(exprTableDir, "mut_genes.expr.perc.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -2796,14 +2734,14 @@ The <span style="color:#ff0000">RED</span> colour range indicate relatively **hi
 #### Z-scores
 
 ```{r mut_genes_table, comment = NA, message=FALSE, warning=FALSE, eval = runPcgrChunk, results = "asis"}
-mut_genes.expr.z <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
+mut_genes.expr.z <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
 
 ##### Present the expression summary table
 mut_genes.expr.z
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=mut_genes.expr.z, file=paste(exprTableDir, "mut_genes.expr.z.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = mut_genes.expr.z, file = paste(exprTableDir, "mut_genes.expr.z.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space
@@ -2835,31 +2773,30 @@ output_counts <- list()
 output_density <- list()
 genes <- mut_genes.expr.perc[[2]]$SYMBOL
 
-##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample 
-for( i in 1:genes_no ) {
-  if ( genes_no > 0 && genes[i] %in% rownames(data) ) {
-    
+##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample
+for (i in 1:genes_no) {
+  if (genes_no > 0 && genes[i] %in% rownames(data)) {
     ##### CDF plot
     output_cdf[[i]] <- cdfPlot(gene = genes[i], data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, addBoxPlot = TRUE, scaling = scaling, report_dir = results_dir)
-    
+
     ##### Bar-plot of read counts
     ##### First map the gene symbol to Ensmebl ID (used in the counts data)
-    genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL ==  genes[i] ]
-    
-    output_counts[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group )
-    
+    genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL == genes[i]]
+
+    output_counts[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group)
+
     ##### Density plot - expression distribution
-    output_density[[i]] <- densityPlot(gene = genes[i], data = data, main_title= "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling) 
+    output_density[[i]] <- densityPlot(gene = genes[i], data = data, main_title = "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling)
   }
-  
+
   #### Clear plots to free up some memory
-  if(!is.null(dev.list())) invisible(dev.off())
+  if (!is.null(dev.list())) invisible(dev.off())
 }
 
 ##### Now once the plots are ready show them in separate tabs
-if ( genes_no != 0 ) {
-  for( i in 1:genes_no ){
-    if ( genes[i] %in% rownames(data) ) {
+if (genes_no != 0) {
+  for (i in 1:genes_no) {
+    if (genes[i] %in% rownames(data)) {
       cat("\n#### ", genes[i], "\n")
       cat(renderTags(output_cdf[[i]])$html)
       cat("\n<details>\n")
@@ -2892,18 +2829,17 @@ if ( genes_no != 0 ) {
     }
   }
   #### Clear plots to free up some memory
-  if(!is.null(dev.list())) invisible(dev.off())
-  
+  if (!is.null(dev.list())) invisible(dev.off())
 } else {
   cat("\nNo alterations were reported.\n")
-   cat("\n***\n")
+  cat("\n***\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 ##### Clean the space
-rm(list = ls(pattern='^output*'))
+rm(list = ls(pattern = "^output*"))
 rm(limit_genes)
 ```
 
@@ -2957,96 +2893,90 @@ Out of the `r if ( runFusionChunk ) { nrow(fusions) } else { c("0") }` fusion ev
 
 ```{r fusions_summary_table, comment = NA, message=FALSE, warning=FALSE}
 ##### Create a nice table output (with dataTable)
-if ( runFusionChunk ) {
-  
+if (runFusionChunk) {
   ##### Update MySQL commend to populate RNA-seq data portal
   mysql_populate <- paste0(mysql_populate, ",Fusion genes")
   mysql_populate_update <- paste0(mysql_populate_update, ",Fusion genes")
-  
+
   fusions.table <- fusions
   fusions.table$geneA <- as.vector(fusions.table$geneA)
   fusions.table$geneB <- as.vector(fusions.table$geneB)
-  
+
   ##### Provide link to FusionGDB
-  for ( i in 1:nrow(fusions.table) ) {
-      if ( fusions.table$reported_fusion[i] == "Yes" ) {
-        fusions.table$geneA[i] <- paste0("<a href='https://ccsm.uth.edu/FusionGDB/gene_search_result.cgi?page=page&type=quick_search&quick_search=", fusions.table$FGID[i], "' target='_blank'>", fusions.table$geneA[i], "</a>")
-  
-        fusions.table$geneB[i] <- paste0("<a href='https://ccsm.uth.edu/FusionGDB/gene_search_result.cgi?page=page&type=quick_search&quick_search=", fusions.table$FGID[i], "' target='_blank'>", fusions.table$geneB[i], "</a>")
-      }
+  for (i in 1:nrow(fusions.table)) {
+    if (fusions.table$reported_fusion[i] == "Yes") {
+      fusions.table$geneA[i] <- paste0("<a href='https://ccsm.uth.edu/FusionGDB/gene_search_result.cgi?page=page&type=quick_search&quick_search=", fusions.table$FGID[i], "' target='_blank'>", fusions.table$geneA[i], "</a>")
+
+      fusions.table$geneB[i] <- paste0("<a href='https://ccsm.uth.edu/FusionGDB/gene_search_result.cgi?page=page&type=quick_search&quick_search=", fusions.table$FGID[i], "' target='_blank'>", fusions.table$geneB[i], "</a>")
+    }
   }
-  
+
   ##### Dragen + Arriba
-  if ( runDragenFusionChunk && runArribaChunk ) {
-    fusions.table <- fusions.table[ , names(fusions.table) %!in% "FGID" ]
-    fusions.table <- fusions.table[ , c("geneA", "geneB", "split_reads", "split_readsA", "split_readsB", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "confidence", "score", "breakpointA", "breakpointB", "siteA", "siteB", "type", "circos")]
-  names(fusions.table) <- c("Gene A", "Gene B", "Split reads (Total)", "Split reads (A)", "Split reads (B)", "Pair reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)", "Fusion gene (A)", "Fusion gene (B)", "Confidence (Arriba)", "Score (Dragen)", "Breakpoint (A)", "Breakpoint (B)", "Site (A)", "Site (B)", "Type", "Genomic view")
-  
-  ##### Arriba / Arriba + Pizzly
-  } else if ( runArribaChunk ) {
-    fusions.table <- fusions.table[ , names(fusions.table) %!in% "FGID" ]
-    fusions.table <- fusions.table[ , c("geneA", "geneB", "split_reads", "split_readsA", "split_readsB", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "confidence", "breakpointA", "breakpointB", "siteA", "siteB", "type", "circos")]
-  names(fusions.table) <- c("Gene A", "Gene B", "Split reads (Total)", "Split reads (A)", "Split reads (B)", "Pair reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)", "Fusion gene (A)", "Fusion gene (B)", "Confidence (Arriba)", "Breakpoint (A)", "Breakpoint (B)", "Site (A)", "Site (B)", "Type", "Genomic view")
-  
-  ##### Dragen only
-  } else if ( runDragenFusionChunk ) {
-    
+  if (runDragenFusionChunk && runArribaChunk) {
+    fusions.table <- fusions.table[, names(fusions.table) %!in% "FGID"]
+    fusions.table <- fusions.table[, c("geneA", "geneB", "split_reads", "split_readsA", "split_readsB", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "confidence", "score", "breakpointA", "breakpointB", "siteA", "siteB", "type", "circos")]
+    names(fusions.table) <- c("Gene A", "Gene B", "Split reads (Total)", "Split reads (A)", "Split reads (B)", "Pair reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)", "Fusion gene (A)", "Fusion gene (B)", "Confidence (Arriba)", "Score (Dragen)", "Breakpoint (A)", "Breakpoint (B)", "Site (A)", "Site (B)", "Type", "Genomic view")
+
+    ##### Arriba / Arriba + Pizzly
+  } else if (runArribaChunk) {
+    fusions.table <- fusions.table[, names(fusions.table) %!in% "FGID"]
+    fusions.table <- fusions.table[, c("geneA", "geneB", "split_reads", "split_readsA", "split_readsB", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "confidence", "breakpointA", "breakpointB", "siteA", "siteB", "type", "circos")]
+    names(fusions.table) <- c("Gene A", "Gene B", "Split reads (Total)", "Split reads (A)", "Split reads (B)", "Pair reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)", "Fusion gene (A)", "Fusion gene (B)", "Confidence (Arriba)", "Breakpoint (A)", "Breakpoint (B)", "Site (A)", "Site (B)", "Type", "Genomic view")
+
+    ##### Dragen only
+  } else if (runDragenFusionChunk) {
     #####  Dragen's fusion format version 3.9.3
-    if ( all(c("GeneALocation", "GeneBLocation", "NumSplitReads","NumSoftClippedReads", "Score") %in% colnames(dragen.fusions)) ) {
-        fusions.table <- fusions.table[ , names(fusions.table) %!in% "FGID" ]
-        fusions.table <- fusions.table[ , c("geneA", "geneB", "split_reads", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "score", "breakpointA", "breakpointB", "siteA", "siteB", "circos")]
+    if (all(c("GeneALocation", "GeneBLocation", "NumSplitReads", "NumSoftClippedReads", "Score") %in% colnames(dragen.fusions))) {
+      fusions.table <- fusions.table[, names(fusions.table) %!in% "FGID"]
+      fusions.table <- fusions.table[, c("geneA", "geneB", "split_reads", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "score", "breakpointA", "breakpointB", "siteA", "siteB", "circos")]
       names(fusions.table) <- c("Gene A", "Gene B", "Split reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)", "Fusion gene (A)", "Fusion gene (B)", "Score", "Breakpoint (A)", "Breakpoint (B)", "Site (A)", "Site (B)", "Genomic view")
-      
-    #####  Dragen's fusion format prior to version 3.9.3
+
+      #####  Dragen's fusion format prior to version 3.9.3
     } else {
-      fusions.table <- fusions.table[ , names(fusions.table) %!in% "FGID" ]
-        fusions.table <- fusions.table[ , c("geneA", "geneB", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "score", "breakpointA", "breakpointB", "circos")]
+      fusions.table <- fusions.table[, names(fusions.table) %!in% "FGID"]
+      fusions.table <- fusions.table[, c("geneA", "geneB", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "score", "breakpointA", "breakpointB", "circos")]
       names(fusions.table) <- c("Gene A", "Gene B", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)", "Fusion gene (A)", "Fusion gene (B)", "Score", "Breakpoint (A)", "Breakpoint (B)", "Genomic view")
     }
-  
-  ##### Pizzly only
+
+    ##### Pizzly only
   } else {
-    fusions.table <- fusions.table[ , names(fusions.table) %!in% "FGID" ]
-    fusions.table <- fusions.table[ , c("geneA", "geneB", "split_reads", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "circos")]
-  names(fusions.table) <- c("Gene A", "Gene B", "Split reads", "Pair reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)", "Fusion gene (A)", "Fusion gene (B)", "Genomic view")
+    fusions.table <- fusions.table[, names(fusions.table) %!in% "FGID"]
+    fusions.table <- fusions.table[, c("geneA", "geneB", "split_reads", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer", "reported_fusion_geneA", "reported_fusion_geneB", "circos")]
+    names(fusions.table) <- c("Gene A", "Gene B", "Split reads", "Pair reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)", "Fusion gene (A)", "Fusion gene (B)", "Genomic view")
   }
-  
+
   ##### Present gene fusion events in a table
-  fusions.summary <- DT::datatable( data = fusions.table, filter = "none", rownames = FALSE, extensions = c('Buttons','Scroller'), options = list(pageLength = 10, dom = 'Bfrtip', buttons = c('excel', 'csv', 'pdf','copy','colvis'), scrollX = TRUE, deferRender = TRUE, scrollY = "333px", scroller = TRUE), width = 800, height = 490, caption = htmltools::tags$caption(style = 'caption-side: top; text-align: left; color:grey; font-size:100% ;'), escape = FALSE) %>%
-      DT::formatStyle( columns = names(fusions.table), `font-size` = '12px', 'text-align' = 'center' ) %>%
-    
-      ##### Highlight rows with fusions involving cancer genes (grey) or DNA support (from MANTA, orange)
-      DT::formatStyle( columns = colnames(fusions.table) %in% "Cancer gene(s)", backgroundColor = DT::styleEqual(c("-", "Yes"), c('transparent', 'lightgrey')) ) %>%
-      DT::formatStyle( columns = colnames(fusions.table) %in% "DNA support (A)", backgroundColor = DT::styleEqual(c("-", "Yes"), c('transparent', 'coral')) ) %>%
-      DT::formatStyle( columns = colnames(fusions.table) %in% "DNA support (B)", backgroundColor = DT::styleEqual(c("-", "Yes"), c('transparent', 'coral')) ) %>%
-      DT::formatStyle( columns = colnames(fusions.table) %in% "Reported fusion", backgroundColor = DT::styleEqual( c("-", "Yes"), c('transparent', 'lightgreen')) )
-  
+  fusions.summary <- DT::datatable(data = fusions.table, filter = "none", rownames = FALSE, extensions = c("Buttons", "Scroller"), options = list(pageLength = 10, dom = "Bfrtip", buttons = c("excel", "csv", "pdf", "copy", "colvis"), scrollX = TRUE, deferRender = TRUE, scrollY = "333px", scroller = TRUE), width = 800, height = 490, caption = htmltools::tags$caption(style = "caption-side: top; text-align: left; color:grey; font-size:100% ;"), escape = FALSE) %>%
+    DT::formatStyle(columns = names(fusions.table), `font-size` = "12px", "text-align" = "center") %>%
+    ##### Highlight rows with fusions involving cancer genes (grey) or DNA support (from MANTA, orange)
+    DT::formatStyle(columns = colnames(fusions.table) %in% "Cancer gene(s)", backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "lightgrey"))) %>%
+    DT::formatStyle(columns = colnames(fusions.table) %in% "DNA support (A)", backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "coral"))) %>%
+    DT::formatStyle(columns = colnames(fusions.table) %in% "DNA support (B)", backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "coral"))) %>%
+    DT::formatStyle(columns = colnames(fusions.table) %in% "Reported fusion", backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "lightgreen")))
+
   fusions.summary
-  
 } else {
-  
   ##### Create empty table
   fusions.table <- data.frame(matrix(ncol = 13, nrow = 0))
-  
+
   names(fusions.table) <- c("Gene A", "Gene B", "Split reads", "Pair reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)", "Fusion gene (A)", "Fusion gene (B)", "Breakpoint (A)", "Breakpoint (B)", "Genomic view")
 
   ##### Present gene fusion events in a table
-  fusions.summary <- DT::datatable( data = fusions.table, filter = "none", rownames = FALSE, extensions = c('Buttons','Scroller'), options = list(pageLength = 10, dom = 'Bfrtip', buttons = c('excel', 'csv', 'pdf','copy','colvis'), scrollX = TRUE, deferRender = TRUE, scrollY = "333px", scroller = TRUE), width = 800, height = 490, caption = htmltools::tags$caption(style = 'caption-side: top; text-align: left; color:grey; font-size:100% ;'), escape = FALSE) %>%
-      DT::formatStyle( columns = names(fusions.table), `font-size` = '12px', 'text-align' = 'center' )
-  
+  fusions.summary <- DT::datatable(data = fusions.table, filter = "none", rownames = FALSE, extensions = c("Buttons", "Scroller"), options = list(pageLength = 10, dom = "Bfrtip", buttons = c("excel", "csv", "pdf", "copy", "colvis"), scrollX = TRUE, deferRender = TRUE, scrollY = "333px", scroller = TRUE), width = 800, height = 490, caption = htmltools::tags$caption(style = "caption-side: top; text-align: left; color:grey; font-size:100% ;"), escape = FALSE) %>%
+    DT::formatStyle(columns = names(fusions.table), `font-size` = "12px", "text-align" = "center")
+
   fusions.summary
 }
 
 ##### Save the table as html file
-if ( params$save_tables ) {
-  
+if (params$save_tables) {
   ##### Create directory for tables
   fusionsTableDir <- paste(results_dir, "fusionsTables", sep = "/")
-  if ( !file.exists(fusionsTableDir) ) {
-          dir.create(fusionsTableDir, recursive=TRUE)
+  if (!file.exists(fusionsTableDir)) {
+    dir.create(fusionsTableDir, recursive = TRUE)
   }
 
-  saveWidgetFix(widget=fusions.summary, file=paste(fusionsTableDir, "fusions.summary.html", sep = "/"), selfcontained=TRUE)
+  saveWidgetFix(widget = fusions.summary, file = paste(fusionsTableDir, "fusions.summary.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space and return output
@@ -3090,34 +3020,33 @@ Fusion events are ordered by the following columns:
 
 ```{r circos_prep, comment = NA, message=FALSE, warning=FALSE, fig.width = 8, fig.height = 8, eval = runFusionChunk}
 ##### Keep only reported fusions or those with or cancer gene(s) involved
-if ( runSVsChunk ) {
-  fusion_annot_top <- fusion_annot[ fusion_annot$reported_fusion == "Yes" | fusion_annot$geneA_dna_support == "Yes" | fusion_annot$geneB_dna_support == "Yes" , ]
+if (runSVsChunk) {
+  fusion_annot_top <- fusion_annot[fusion_annot$reported_fusion == "Yes" | fusion_annot$geneA_dna_support == "Yes" | fusion_annot$geneB_dna_support == "Yes", ]
 } else {
-  fusion_annot_top <- fusion_annot[ fusion_annot$reported_fusion == "Yes" , ]
+  fusion_annot_top <- fusion_annot[fusion_annot$reported_fusion == "Yes", ]
 }
 
-if ( nrow(fusion_annot_top) > 0 ) {
-  
+if (nrow(fusion_annot_top) > 0) {
   ##### Create folder for fusion plots
   fusionsPlotDir <- paste(results_dir, "fusionsPlot", sep = "/")
-    
-  if ( !file.exists(fusionsPlotDir) ) {
-    dir.create(fusionsPlotDir, recursive=TRUE)
+
+  if (!file.exists(fusionsPlotDir)) {
+    dir.create(fusionsPlotDir, recursive = TRUE)
   }
-  
+
   ##### Prepare object for RCircos
-  eval(parse( text=paste0("data(UCSC.HG", params$ucsc_genome_assembly, ".Human.CytoBandIdeogram)")))
-  cyto.info <- eval(parse( text=paste0("UCSC.HG", params$ucsc_genome_assembly, ".Human.CytoBandIdeogram")))
-    
+  eval(parse(text = paste0("data(UCSC.HG", params$ucsc_genome_assembly, ".Human.CytoBandIdeogram)")))
+  cyto.info <- eval(parse(text = paste0("UCSC.HG", params$ucsc_genome_assembly, ".Human.CytoBandIdeogram")))
+
   ##### Check if all driver genes are located in standard chromosomes
-  fusion_annot_top <- fusion_annot_top[ paste0("chr", fusion_annot_top$SEQNAME) %in% cyto.info$Chromosome,  ]
-  
-  fusion_annot_top.circos.pairs <- fusion_annot_top[, c("SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL","SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "SYMBOL.1")]
-  
+  fusion_annot_top <- fusion_annot_top[paste0("chr", fusion_annot_top$SEQNAME) %in% cyto.info$Chromosome, ]
+
+  fusion_annot_top.circos.pairs <- fusion_annot_top[, c("SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL", "SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "SYMBOL.1")]
+
   ##### Add "chr" to chromosome numbers
   fusion_annot_top.circos.pairs$SEQNAME <- paste0("chr", fusion_annot_top.circos.pairs$SEQNAME)
   fusion_annot_top.circos.pairs$SEQNAME.1 <- paste0("chr", fusion_annot_top.circos.pairs$SEQNAME.1)
-  
+
   ##### Change column names
   names(fusion_annot_top.circos.pairs) <- gsub("SEQNAME", "Chromosome", names(fusion_annot_top.circos.pairs))
   names(fusion_annot_top.circos.pairs) <- gsub("GENESEQSTART", "chromStart", names(fusion_annot_top.circos.pairs))
@@ -3127,108 +3056,102 @@ if ( nrow(fusion_annot_top) > 0 ) {
   names(fusion_annot_top.circos.pairs) <- gsub("chromStart.1", "chromStart", names(fusion_annot_top.circos.pairs))
   names(fusion_annot_top.circos.pairs) <- gsub("chromEnd.1", "chromEnd", names(fusion_annot_top.circos.pairs))
   names(fusion_annot_top.circos.pairs) <- gsub("Gene.1", "Gene", names(fusion_annot_top.circos.pairs))
-  
+
   ##### Remove entries with missing genomic coordinates
   fusion_annot_top.circos.pairs <- fusion_annot_top.circos.pairs[complete.cases(fusion_annot_top.circos.pairs), ]
-  fusion_annot_top.circos <- rbind(fusion_annot_top.circos.pairs[, 1:4 ], fusion_annot_top.circos.pairs[, 5:8 ])
-  fusion_annot_top.circos.pairs <- fusion_annot_top.circos.pairs[, colnames(fusion_annot_top.circos.pairs) %!in% c("Gene", "Gene.1") ]
-  
+  fusion_annot_top.circos <- rbind(fusion_annot_top.circos.pairs[, 1:4], fusion_annot_top.circos.pairs[, 5:8])
+  fusion_annot_top.circos.pairs <- fusion_annot_top.circos.pairs[, colnames(fusion_annot_top.circos.pairs) %!in% c("Gene", "Gene.1")]
+
   ##### Generate circos plot
-  RCircos.Set.Core.Components( cyto.info=cyto.info, chr.exclude=NULL, tracks.inside=4, tracks.outside=0 )
-  RCircos.Set.Plot.Area()  
+  RCircos.Set.Core.Components(cyto.info = cyto.info, chr.exclude = NULL, tracks.inside = 4, tracks.outside = 0)
+  RCircos.Set.Plot.Area()
   RCircos.Chromosome.Ideogram.Plot()
-  RCircos.Gene.Connector.Plot(genomic.data = fusion_annot_top.circos, track.num = 1, side="in") 
+  RCircos.Gene.Connector.Plot(genomic.data = fusion_annot_top.circos, track.num = 1, side = "in")
   RCircos.Gene.Name.Plot(gene.data = fusion_annot_top.circos, name.col = 4, track.num = 2, side = "in")
-  RCircos.Link.Plot(link.data = fusion_annot_top.circos.pairs, track.num=4, by.chromosome=TRUE, is.sorted=FALSE, lineWidth=rep(2, nrow(fusion_annot_top.circos.pairs)))
+  RCircos.Link.Plot(link.data = fusion_annot_top.circos.pairs, track.num = 4, by.chromosome = TRUE, is.sorted = FALSE, lineWidth = rep(2, nrow(fusion_annot_top.circos.pairs)))
 }
 ```
 
 ```{r fusions_genomic_view_circos_save, comment = NA, message=FALSE, warning=FALSE, fig.width = 8, fig.height = 3, eval = runFusionChunk}
 ##### Generate circos plot representing gene fusion events. NOTE. Only fusions involving fusion genes supported by MANTA or reported fusions are presented
-if ( nrow(fusion_annot_top) > 0 ) {
-  
+if (nrow(fusion_annot_top) > 0) {
   ##### Save circos into a png file
-  png( filename = paste(fusionsPlotDir, "circosPlot.png", sep="/"), width = 800, height = 800, units = "px", pointsize = 24 )
-  RCircos.Set.Core.Components( cyto.info=cyto.info, chr.exclude=NULL, tracks.inside=4, tracks.outside=0 )
-  RCircos.Set.Plot.Area()  
+  png(filename = paste(fusionsPlotDir, "circosPlot.png", sep = "/"), width = 800, height = 800, units = "px", pointsize = 24)
+  RCircos.Set.Core.Components(cyto.info = cyto.info, chr.exclude = NULL, tracks.inside = 4, tracks.outside = 0)
+  RCircos.Set.Plot.Area()
   RCircos.Chromosome.Ideogram.Plot()
-  RCircos.Gene.Connector.Plot(genomic.data = fusion_annot_top.circos, track.num = 1, side="in") 
+  RCircos.Gene.Connector.Plot(genomic.data = fusion_annot_top.circos, track.num = 1, side = "in")
   RCircos.Gene.Name.Plot(gene.data = fusion_annot_top.circos, name.col = 4, track.num = 2, side = "in")
-  RCircos.Link.Plot(link.data = fusion_annot_top.circos.pairs, track.num=4, by.chromosome=TRUE, is.sorted=FALSE, lineWidth=rep(2, nrow(fusion_annot_top.circos.pairs)))
+  RCircos.Link.Plot(link.data = fusion_annot_top.circos.pairs, track.num = 4, by.chromosome = TRUE, is.sorted = FALSE, lineWidth = rep(2, nrow(fusion_annot_top.circos.pairs)))
   invisible(dev.off())
-    
+
   ##### Clean the space
   rm(fusion_annot_top.circos, fusion_annot_top.circos.pairs)
-  
+
   #### Clear plots to free up some memory
-  if(!is.null(dev.list())) invisible(dev.off())
-  
+  if (!is.null(dev.list())) invisible(dev.off())
 } else {
   cat("None of the transcriptome-based fusion events have supporting evidence from DNA data or was previously reported.")
 }
 ```
 
 ```{r genomic_view_circos_table_fusions, comment = NA, message=FALSE, warning=FALSE, eval = runFusionChunk}
-if ( nrow(fusion_annot_top) > 0 ) {
-  
+if (nrow(fusion_annot_top) > 0) {
   ##### Clean the table for better presentation
   ##### Dragen + Arriba / Pizzly + Arriba
-  if ( runDragenFusionChunk && runArribaChunk ) {
-    fusion_annot_top.clean <- fusion_annot_top[, c("SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL.1", "SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "breakpointA", "breakpointB", "split_reads", "split_readsA", "split_readsB", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer") ]
-    
-  ##### Dragen only
-  } else if ( runDragenFusionChunk ) {
-    
+  if (runDragenFusionChunk && runArribaChunk) {
+    fusion_annot_top.clean <- fusion_annot_top[, c("SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL.1", "SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "breakpointA", "breakpointB", "split_reads", "split_readsA", "split_readsB", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer")]
+
+    ##### Dragen only
+  } else if (runDragenFusionChunk) {
     #####  Dragen's fusion format version 3.9.3
-    if ( all(c("GeneALocation", "GeneBLocation", "NumSplitReads","NumSoftClippedReads", "Score") %in% colnames(dragen.fusions)) ) {
-      fusion_annot_top.clean <- fusion_annot_top[, c("SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL.1", "SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "breakpointA", "breakpointB", "split_reads", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer") ]
-      
-    #####  Dragen's fusion format prior to version 3.9.3
+    if (all(c("GeneALocation", "GeneBLocation", "NumSplitReads", "NumSoftClippedReads", "Score") %in% colnames(dragen.fusions))) {
+      fusion_annot_top.clean <- fusion_annot_top[, c("SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL.1", "SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "breakpointA", "breakpointB", "split_reads", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer")]
+
+      #####  Dragen's fusion format prior to version 3.9.3
     } else {
-      fusion_annot_top.clean <- fusion_annot_top[, c("SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL.1", "SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "breakpointA", "breakpointB", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer") ]
+      fusion_annot_top.clean <- fusion_annot_top[, c("SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL.1", "SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "breakpointA", "breakpointB", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer")]
     }
-    
-  ##### Pizzly only
+
+    ##### Pizzly only
   } else {
-    fusion_annot_top.clean <- fusion_annot_top[, c("SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL.1", "SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "split_reads", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer") ]
+    fusion_annot_top.clean <- fusion_annot_top[, c("SYMBOL", "SEQNAME", "GENESEQSTART", "GENESEQEND", "SYMBOL.1", "SEQNAME.1", "GENESEQSTART.1", "GENESEQEND.1", "split_reads", "discordant_mates", "geneA_dna_support", "geneB_dna_support", "reported_fusion", "fusions_cancer")]
   }
-  
+
   ##### Order fusions based on the genomic location (chrom and start positions)
-  chrOrder <-c((1:22),"X","Y","M")
-  
-  fusion_annot_top.clean$SEQNAME <- factor(fusion_annot_top.clean$SEQNAME, chrOrder, ordered=TRUE)
-  fusion_annot_top.clean$SEQNAME.1 <- factor(fusion_annot_top.clean$SEQNAME.1, chrOrder, ordered=TRUE)
+  chrOrder <- c((1:22), "X", "Y", "M")
+
+  fusion_annot_top.clean$SEQNAME <- factor(fusion_annot_top.clean$SEQNAME, chrOrder, ordered = TRUE)
+  fusion_annot_top.clean$SEQNAME.1 <- factor(fusion_annot_top.clean$SEQNAME.1, chrOrder, ordered = TRUE)
   fusion_annot_top.clean <- fusion_annot_top.clean[do.call(order, fusion_annot_top.clean[, c("SEQNAME", "SEQNAME.1", "GENESEQSTART", "GENESEQSTART.1")]), ]
-  
+
   ##### Dragen + Arriba / Pizzly + Arriba
-  if ( runDragenFusionChunk && runArribaChunk) {
+  if (runDragenFusionChunk && runArribaChunk) {
     names(fusion_annot_top.clean) <- c("Gene A", "Chrom (A)", "Start (A)", "End (A)", "Gene B", "Chrom (B)", "Start (B)", "End (B)", "Breakpoint (A)", "Breakpoint (B)", "Split reads (Total)", "Split reads (A)", "Split reads (B)", "Pair reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)")
-    
-  ##### Dragen only
-  } else if ( runDragenFusionChunk ) {
-    
+
+    ##### Dragen only
+  } else if (runDragenFusionChunk) {
     #####  Dragen's fusion format version 3.9.3
-    if ( all(c("GeneALocation", "GeneBLocation", "NumSplitReads","NumSoftClippedReads", "Score") %in% colnames(dragen.fusions)) ) {
+    if (all(c("GeneALocation", "GeneBLocation", "NumSplitReads", "NumSoftClippedReads", "Score") %in% colnames(dragen.fusions))) {
       names(fusion_annot_top.clean) <- c("Gene A", "Chrom (A)", "Start (A)", "End (A)", "Gene B", "Chrom (B)", "Start (B)", "End (B)", "Breakpoint (A)", "Breakpoint (B)", "Split reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)")
-      
-    #####  Dragen's fusion format prior to version 3.9.3
+
+      #####  Dragen's fusion format prior to version 3.9.3
     } else {
       names(fusion_annot_top.clean) <- c("Gene A", "Chrom (A)", "Start (A)", "End (A)", "Gene B", "Chrom (B)", "Start (B)", "End (B)", "Breakpoint (A)", "Breakpoint (B)", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)")
     }
-    
-  ##### Pizzly only
+
+    ##### Pizzly only
   } else {
     names(fusion_annot_top.clean) <- c("Gene A", "Chrom (A)", "Start (A)", "End (A)", "Gene B", "Chrom (B)", "Start (B)", "End (B)", "Split reads", "Pair reads", "DNA support (A)", "DNA support (B)", "Reported fusion", "Cancer gene(s)")
   }
 
-  fusions.genomicView <- DT::datatable( data = fusion_annot_top.clean, filter="none", rownames = FALSE, extensions = c('Buttons','Scroller'), options = list(pageLength = 10, dom = 'Bfrtip', buttons = c('excel', 'csv', 'pdf','copy','colvis'), scrollX = TRUE, deferRender = TRUE, scrollY = "167px", scroller = TRUE), width = 800, height = 318,  escape = FALSE) %>%
-      DT::formatStyle( columns = names(fusion_annot_top.clean), `font-size` = '12px', 'text-align' = 'center' ) %>%
-    
-      ##### Highlight rows with fusions involving cancer genes (grey)
-      DT::formatStyle( columns = colnames(fusion_annot_top.clean) %in% "Cancer gene(s)", backgroundColor = DT::styleEqual(c("-", "Yes"), c('transparent', 'lightgrey')) ) %>%
-      DT::formatStyle( columns = colnames(fusion_annot_top.clean) %in% "DNA support (A)", backgroundColor = DT::styleEqual(c("-", "Yes"), c('transparent', 'coral')) ) %>%
-      DT::formatStyle( columns = colnames(fusion_annot_top.clean) %in% "DNA support (B)", backgroundColor = DT::styleEqual(c("-", "Yes"), c('transparent', 'coral')) ) %>%
-    DT::formatStyle( columns = colnames(fusion_annot_top.clean) %in% "Reported fusion", backgroundColor = DT::styleEqual( c("-", "Yes"), c('transparent', 'lightgreen')) )
+  fusions.genomicView <- DT::datatable(data = fusion_annot_top.clean, filter = "none", rownames = FALSE, extensions = c("Buttons", "Scroller"), options = list(pageLength = 10, dom = "Bfrtip", buttons = c("excel", "csv", "pdf", "copy", "colvis"), scrollX = TRUE, deferRender = TRUE, scrollY = "167px", scroller = TRUE), width = 800, height = 318, escape = FALSE) %>%
+    DT::formatStyle(columns = names(fusion_annot_top.clean), `font-size` = "12px", "text-align" = "center") %>%
+    ##### Highlight rows with fusions involving cancer genes (grey)
+    DT::formatStyle(columns = colnames(fusion_annot_top.clean) %in% "Cancer gene(s)", backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "lightgrey"))) %>%
+    DT::formatStyle(columns = colnames(fusion_annot_top.clean) %in% "DNA support (A)", backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "coral"))) %>%
+    DT::formatStyle(columns = colnames(fusion_annot_top.clean) %in% "DNA support (B)", backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "coral"))) %>%
+    DT::formatStyle(columns = colnames(fusion_annot_top.clean) %in% "Reported fusion", backgroundColor = DT::styleEqual(c("-", "Yes"), c("transparent", "lightgreen")))
 
   fusions.genomicView
 }
@@ -3248,8 +3171,8 @@ Cells in <span style="color:#ff0000">RED</span> indicate **DNA-supported** fusio
 
 ```{r genomic_view_table_fusions_save, comment = NA, message=FALSE, warning=FALSE, eval = runFusionChunk}
 ##### Save the table as html file
-if ( nrow(fusion_annot_top) > 0 && params$save_tables ) {
-  saveWidgetFix(widget=fusions.genomicView, file=paste(fusionsTableDir, "fusions.genomicView.html", sep = "/"), selfcontained=TRUE)  
+if (nrow(fusion_annot_top) > 0 && params$save_tables) {
+  saveWidgetFix(widget = fusions.genomicView, file = paste(fusionsTableDir, "fusions.genomicView.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space and return output
@@ -3282,10 +3205,10 @@ output_table_Z <- list()
 output_table_perc <- list()
 
 ##### Deal with no genes or when more than 10 genes are of interest
-if ( length(genes) == 0 ) {
+if (length(genes) == 0) {
   genes <- NULL
   genes_no <- 0
-} else if ( length(genes) > params$top_genes ) {
+} else if (length(genes) > params$top_genes) {
   genes_no <- params$top_genes
 } else {
   genes_no <- length(genes)
@@ -3295,89 +3218,87 @@ if ( length(genes) == 0 ) {
 genes <- c(genes, as.character(fusions$geneB))
 
 ##### Collect info and plots for each of the top fusions
-for( i in 1:genes_no ) {
-  if ( genes_no > 0 ) {
+for (i in 1:genes_no) {
+  if (genes_no > 0) {
     geneA <- as.vector(fusions$geneA[i])
     geneB <- as.vector(fusions$geneB[i])
-    
-    ##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample 
-    if ( geneA %in% rownames(data) ) {
-      
+
+    ##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample
+    if (geneA %in% rownames(data)) {
       ##### CDF plot
       output_cdf_A[[i]] <- cdfPlot(gene = geneA, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, addBoxPlot = FALSE, scaling = scaling, report_dir = results_dir)
-      
+
       ##### Bar-plot of read counts
       ##### First map the gene symbol to Ensmebl ID (used in the counts data)
-      genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL ==  geneA ]
-      
-      output_counts_A[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group )
-      
+      genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL == geneA]
+
+      output_counts_A[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group)
+
       ##### Density plot - expression distribution
-      output_density_A[[i]] <- densityPlot(gene = geneA, data = data, main_title= "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling)
+      output_density_A[[i]] <- densityPlot(gene = geneA, data = data, main_title = "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling)
     }
-    
+
     ##### Gene B
-    if ( geneB %in% rownames(data) && geneB != geneA) {
-      
+    if (geneB %in% rownames(data) && geneB != geneA) {
       ##### CDF plot
       output_cdf_B[[i]] <- cdfPlot(gene = geneB, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, addBoxPlot = FALSE, scaling = scaling, report_dir = results_dir)
-      
+
       ##### Bar-plot of read counts
       ##### First map the gene symbol to Ensmebl ID (used in the counts data)
-      genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL ==  geneB ]
-      
-      output_counts_B[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group )
-      
+      genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL == geneB]
+
+      output_counts_B[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group)
+
       ##### Density plot - expression distribution
-      output_density_B[[i]] <- densityPlot(gene = geneB, data = data, main_title= "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling) 
+      output_density_B[[i]] <- densityPlot(gene = geneB, data = data, main_title = "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling)
     }
-      
+
     ##### Generate expression summary tables
     genes <- c(geneA, geneB)
-      
+
     ##### Z-scores
-    output_table_Z[[i]] <- exprTable( genes = unique(genes), data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Germline") ], fusion_genes = unique(known_translocations$geneA, known_translocations$geneB ), ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
-      
+    output_table_Z[[i]] <- exprTable(genes = unique(genes), data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Germline")], fusion_genes = unique(known_translocations$geneA, known_translocations$geneB), ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
+
     ##### Percentiles
-    output_table_perc[[i]] <- exprTable( genes = unique(genes), data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Germline") ], fusion_genes = unique(known_translocations$geneA, known_translocations$geneB ), ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
+    output_table_perc[[i]] <- exprTable(genes = unique(genes), data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Germline")], fusion_genes = unique(known_translocations$geneA, known_translocations$geneB), ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
   }
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 ```{r top_hits_fusions_display, echo=FALSE, comment = NA, message=FALSE, warning=FALSE, fig.width = 8, fig.height = 2.5, eval = runFusionChunk, results="asis"}
 ##### Now once the plots are ready show them in separate tabs
-if ( genes_no > 0 ) {
-  for( i in 1:genes_no ) {
+if (genes_no > 0) {
+  for (i in 1:genes_no) {
     geneA <- as.vector(fusions$geneA[i])
     geneB <- as.vector(fusions$geneB[i])
-    
+
     breakpointA <- as.vector(fusions$breakpointA[i])
     breakpointB <- as.vector(fusions$breakpointB[i])
-    
-    cat("\n#### ", paste(fusions$geneA[i], fusions$geneB[i], sep="-"), "\n")
-    
+
+    cat("\n#### ", paste(fusions$geneA[i], fusions$geneB[i], sep = "-"), "\n")
+
     ##### Check if Arriba fusion plot exists. Skip this section if it doesn't
-    if ( file.exists(gsub(":", ".", paste0(results_dir, "/arriba/", make.names(paste(geneA, geneB, sep = "__")), "_", breakpointA, "-", breakpointB, ".png"))) ) {
+    if (file.exists(gsub(":", ".", paste0(results_dir, "/arriba/", make.names(paste(geneA, geneB, sep = "__")), "_", breakpointA, "-", breakpointB, ".png")))) {
       cat("\n##### Fusion genes visualisation\n")
-  
+
       ##### Present Arriba plots it in the report
       cat(paste0("![](", gsub(":", ".", paste0(results_dir, "/arriba/", make.names(paste(geneA, geneB, sep = "__")), "_", breakpointA, "-", breakpointB, ".png)"))), "\n")
       cat("\n***\n")
     }
-    
+
     cat("\n##### Fusion genes expression\n")
     cat("\nmRNA expression levels of fusion genes detected in patient's sample and their average mRNA expression (Z-score) in samples from cancer cohorts.\n")
-      
+
     ##### Display CDF plots for each fusion gene pair
     suppressMessages(library(plotly))
-      
-    if ( geneA %in% rownames(data) ) {
+
+    if (geneA %in% rownames(data)) {
       cat(renderTags(output_cdf_A[[i]])$html)
       cat("\n<details>\n")
       cat("\n<summary>Plot legend</summary>\n")
@@ -3403,10 +3324,10 @@ if ( genes_no > 0 ) {
     } else {
       cat(paste0("\n<span style=\"color:#ff0000\">NOTE</span>, expression data is not available for ", geneA, ".\n"))
     }
-    
-    if ( geneB == geneA ) {
+
+    if (geneB == geneA) {
       cat(paste0("\n"))
-    } else if ( geneB %in% rownames(data)  ) {
+    } else if (geneB %in% rownames(data)) {
       cat(renderTags(output_cdf_B[[i]])$html)
       cat("\n<details>\n")
       cat("\n<summary>Plot legend</summary>\n")
@@ -3432,7 +3353,7 @@ if ( genes_no > 0 ) {
     } else {
       cat(paste0("\n<span style=\"color:#ff0000\">NOTE</span>, expression data is not available for ", geneB, ".\n"))
     }
-      
+
     cat("\n##### Summary table {.tabset}\n")
     cat("\n###### Percentiles\n")
     cat(renderTags(output_table_perc[[i]])$html)
@@ -3443,42 +3364,41 @@ if ( genes_no > 0 ) {
     cat("\nThe <span style=\"color:#ff0000\">RED</span> colour range indicate relatively **high expression** (percentile) values and <span style=\"color:#0000ff\">BLUE</span> colour range indicate relatively **low expression** (percentile) values in individual sample group. The **Diff** (**Patient vs ", comp_cancer_group, " **) column illustrates the difference between percentiles in patient sample and reference cancer cohort for each fusion gene. Genes considered to be oncogenes or tumour suppressor genes, according to [OncoKB](http://oncokb.org/#/cancerGenes){target=\"_blank\"} database, are also indicated. Genes are ordered by **decreasing** absolute values in the **Diff** (**Patient vs ", comp_cancer_group, "**) column. *TSG* - tumour suppressor gene\n")
     cat("\n</font>\n")
     cat("\n</details>\n")
-    
-    if ( length(genes) > 2000 ) { 
-        cat(paste0("<span style=\"color:#ff0000\">NOTE</span>, the table was truncated to 2000 entries.")) 
+
+    if (length(genes) > 2000) {
+      cat(paste0("<span style=\"color:#ff0000\">NOTE</span>, the table was truncated to 2000 entries."))
     }
-    
+
     cat("\n***\n")
-    
+
     cat("\n###### Z-scores\n")
     cat(renderTags(output_table_Z[[i]])$html)
     cat("<br />")
     cat("\n<details>\n")
     cat("\n<summary>Table legend</summary>\n")
     cat("\n<font size=\"2\">\n")
-    cat(paste0("\nThe <span style=\"color:#ff0000\">RED</span> colour range indicate relatively **high expression** (Z-score) values and <span style=\"color:#0000ff\">BLUE</span> colour range indicate relatively **low expression** (Z-score) values in individual sample group. The **Diff** (**Patient vs ",  comp_cancer_group, "**) column illustrates the difference between Z-scores in patient sample and reference cancer cohort for each fusion gene. Genes considered to be oncogenes or tumour suppressor genes, according to [OncoKB](http://oncokb.org/#/cancerGenes){target=\"_blank\"} database, are also indicated. Genes are ordered by **decreasing** absolute values in the **Diff** (**Patient vs ", comp_cancer_group, "**) column. *TSG* - tumour suppressor gene\n"))
+    cat(paste0("\nThe <span style=\"color:#ff0000\">RED</span> colour range indicate relatively **high expression** (Z-score) values and <span style=\"color:#0000ff\">BLUE</span> colour range indicate relatively **low expression** (Z-score) values in individual sample group. The **Diff** (**Patient vs ", comp_cancer_group, "**) column illustrates the difference between Z-scores in patient sample and reference cancer cohort for each fusion gene. Genes considered to be oncogenes or tumour suppressor genes, according to [OncoKB](http://oncokb.org/#/cancerGenes){target=\"_blank\"} database, are also indicated. Genes are ordered by **decreasing** absolute values in the **Diff** (**Patient vs ", comp_cancer_group, "**) column. *TSG* - tumour suppressor gene\n"))
     cat("\n</font>\n")
     cat("\n</details>\n")
-    
-    if ( length(genes) > 2000 ) { 
-        cat(paste0("<span style=\"color:#ff0000\">NOTE</span>, the table was truncated to 2000 entries.")) 
+
+    if (length(genes) > 2000) {
+      cat(paste0("<span style=\"color:#ff0000\">NOTE</span>, the table was truncated to 2000 entries."))
     }
-    
+
     cat("\n***\n")
   }
   #### Clear plots to free up some memory
-  if(!is.null(dev.list())) invisible(dev.off())
-  
+  if (!is.null(dev.list())) invisible(dev.off())
 } else {
   cat("\nNo alterations were reported.\n")
-   cat("\n***\n")
+  cat("\n***\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 ##### Clean the space
-rm(list = ls(pattern='^output*'))
+rm(list = ls(pattern = "^output*"))
 ```
 
 ***
@@ -3507,14 +3427,14 @@ data <- ref_dataset.list[[dataset]][["data_to_report"]]
 
 ##### Consider only SVs with known genes and those in MANTA output for which the expression levels were measured
 genes <- unique(manta_sv$Gene)
-genes <- genes[ genes %in% ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL ]
+genes <- genes[genes %in% ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL]
 
 ##### Deal with no genes or when more than 10 genes are of interest
-if ( length(genes) == 0 ) {
+if (length(genes) == 0) {
   genes <- NULL
   limit_genes <- FALSE
   genes_no <- 0
-} else if ( length(genes) > params$top_genes ) {
+} else if (length(genes) > params$top_genes) {
   limit_genes <- TRUE
   genes_no <- params$top_genes
 } else {
@@ -3522,14 +3442,14 @@ if ( length(genes) == 0 ) {
   genes_no <- length(genes)
 }
 
-sv_genes.expr.perc <- exprTable( genes = genes, data = data, sv_data = manta_sv, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+sv_genes.expr.perc <- exprTable(genes = genes, data = data, sv_data = manta_sv, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 
 ##### Present the expression summary table
 sv_genes.expr.perc[[1]]
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=sv_genes.expr.perc[[1]], file=paste(exprTableDir, "sv_genes.expr.perc.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = sv_genes.expr.perc[[1]], file = paste(exprTableDir, "sv_genes.expr.perc.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -3552,14 +3472,14 @@ The <span style="color:#ff0000">RED</span> colour range indicate relatively **hi
 
 ```{r sv_genes_table, comment = NA, message=FALSE, warning=FALSE, eval = runSVsChunk}
 ##### Generate expression summary table for cancer genes from OncoKB and UMCCR (https://github.com/vladsaveliev/NGS_Utils/blob/master/ngs_utils/reference_data/key_genes/umccr_cancer_genes.2019-03-20.tsv)
-sv_genes.expr.z <- exprTable( genes = genes, data = data, sv_data = manta_sv, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
+sv_genes.expr.z <- exprTable(genes = genes, data = data, sv_data = manta_sv, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
 
 ##### Present the expression summary table
 sv_genes.expr.z
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=sv_genes.expr.z, file=paste(exprTableDir, "sv_genes.expr.z.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = sv_genes.expr.z, file = paste(exprTableDir, "sv_genes.expr.z.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space
@@ -3593,28 +3513,27 @@ output_counts <- list()
 output_density <- list()
 genes <- unique(sv_genes.expr.perc[[2]]$SYMBOL)
 
-##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample 
-for( i in 1:genes_no ) {
-  if ( genes_no > 0 && genes[i] %in% rownames(data) ) {
-    
+##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample
+for (i in 1:genes_no) {
+  if (genes_no > 0 && genes[i] %in% rownames(data)) {
     ##### CDF plot
     output_cdf[[i]] <- cdfPlot(gene = genes[i], data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, addBoxPlot = TRUE, scaling = scaling, report_dir = results_dir)
-    
+
     ##### Bar-plot of read counts
     ##### First map the gene symbol to Ensmebl ID (used in the counts data)
-    genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL ==  genes[i] ]
-    
-    output_counts[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group )
-    
+    genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL == genes[i]]
+
+    output_counts[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group)
+
     ##### Density plot - expression distribution
-    output_density[[i]] <- densityPlot(gene = genes[i], data = data, main_title= "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling) 
+    output_density[[i]] <- densityPlot(gene = genes[i], data = data, main_title = "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling)
   }
 }
 
 ##### Now once the plots are ready show them in separate tabs
-if ( genes_no != 0 ) {
-  for( i in 1:genes_no ){
-    if ( genes[i] %in% rownames(data) ) {
+if (genes_no != 0) {
+  for (i in 1:genes_no) {
+    if (genes[i] %in% rownames(data)) {
       cat("\n#### ", genes[i], "\n")
       cat(renderTags(output_cdf[[i]])$html)
       cat("\n<details>\n")
@@ -3646,18 +3565,17 @@ if ( genes_no != 0 ) {
     }
   }
   #### Clear plots to free up some memory
-  if(!is.null(dev.list())) invisible(dev.off())
-  
+  if (!is.null(dev.list())) invisible(dev.off())
 } else {
   cat("\nNo alterations were reported.\n")
-   cat("\n***\n")
+  cat("\n***\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 ##### Clean the space
-rm(list = ls(pattern='^output*'))
+rm(list = ls(pattern = "^output*"))
 rm(limit_genes)
 ```
 
@@ -3686,84 +3604,82 @@ data <- ref_dataset.list[[dataset]][["expr_mut_cn_data_all"]]
 data.sub <- ref_dataset.list[[dataset]][["expr_mut_cn_data"]]
 
 ##### Add SNVs
-if ( runPcgrChunk ) {
+if (runPcgrChunk) {
   data$Alterations <- as.character(data$Alterations)
   data.sub$Alterations <- as.character(data.sub$Alterations)
 }
 
 ##### Add fusion genes
-if ( runFusionChunk ) {
-  
+if (runFusionChunk) {
   ##### Change the alteration type to "fusion" for fusion genes
-  data$Alterations[ data$Gene %in% fusions$geneA  ] <- paste0( data$Alterations[ data$Gene %in% fusions$geneA  ], "; Fusion")
-  data.sub$Alterations[ data.sub$Gene %in% fusions$geneA  ] <- paste0( data.sub$Alterations[ data.sub$Gene %in% fusions$geneA  ], "; Fusion")
-  data$Alterations[ data$Gene %in% fusions$geneB  ] <- paste0( data$Alterations[ data$Gene %in% fusions$geneB  ], "; Fusion")
-  data.sub$Alterations[ data.sub$Gene %in% fusions$geneB  ] <- paste0( data.sub$Alterations[ data.sub$Gene %in% fusions$geneB  ], "; Fusion")
+  data$Alterations[data$Gene %in% fusions$geneA] <- paste0(data$Alterations[data$Gene %in% fusions$geneA], "; Fusion")
+  data.sub$Alterations[data.sub$Gene %in% fusions$geneA] <- paste0(data.sub$Alterations[data.sub$Gene %in% fusions$geneA], "; Fusion")
+  data$Alterations[data$Gene %in% fusions$geneB] <- paste0(data$Alterations[data$Gene %in% fusions$geneB], "; Fusion")
+  data.sub$Alterations[data.sub$Gene %in% fusions$geneB] <- paste0(data.sub$Alterations[data.sub$Gene %in% fusions$geneB], "; Fusion")
 }
-            
+
 ##### Add genes involved in SVs (if data available)
-if ( runSVsChunk ) {
-  
+if (runSVsChunk) {
   ##### Change the alteration type to "fusion" for fusion genes
-  data$Alterations[ data$Gene %in% unique(manta_sv$Gene)  ] <- paste0( data$Alterations[ data$Gene %in% unique(manta_sv$Gene)  ], "; SV")
+  data$Alterations[data$Gene %in% unique(manta_sv$Gene)] <- paste0(data$Alterations[data$Gene %in% unique(manta_sv$Gene)], "; SV")
   ##### Change the alteration type to "fusion" for fusion genes
-  data.sub$Alterations[ data.sub$Gene %in% unique(manta_sv$Gene)  ] <- paste0( data.sub$Alterations[ data.sub$Gene %in% unique(manta_sv$Gene)  ], "; SV")
+  data.sub$Alterations[data.sub$Gene %in% unique(manta_sv$Gene)] <- paste0(data.sub$Alterations[data.sub$Gene %in% unique(manta_sv$Gene)], "; SV")
 }
 
 ##### Remove altaration status "None" for gene which are not mutated but are involved in fusions or SVs
-data$Alterations <- gsub( "None", "CN", data$Alterations)
-data.sub$Alterations <- gsub( "None", "CN", data.sub$Alterations)
+data$Alterations <- gsub("None", "CN", data$Alterations)
+data.sub$Alterations <- gsub("None", "CN", data.sub$Alterations)
 
 ##### Prepare dataframe for manhattanly
 ##### Keep only genes for which both genes have gene symbol (and genomics location) available
-data <- data[ data$Gene %in% ref_dataset.list[[dataset]][["gene_annot"]]$SYMBOL, ]
+data <- data[data$Gene %in% ref_dataset.list[[dataset]][["gene_annot"]]$SYMBOL, ]
 names(data)[match("CN", names(data))] <- "P"
 
 ##### Merge genes genomic coordinates info with their annotation and expression data
 data.annot <- merge(data, ref_dataset.list[[dataset]][["gene_annot"]], by.x = "Gene", by.y = "SYMBOL", all.x = FALSE)
 data.annot$SEQNAME <- as.numeric(data.annot$SEQNAME)
 data.annot$GENESEQSTART <- as.numeric(data.annot$GENESEQSTART)
-data.annot <- data.annot[ !is.na(data.annot$SEQNAME), ]
+data.annot <- data.annot[!is.na(data.annot$SEQNAME), ]
 
-if ( nrow(data.annot) > 0 ) {
-  
+if (nrow(data.annot) > 0) {
   ##### Get plot results first to extract x-axis coordinated to annotate genes of interest
   manhattanr.res <- manhattanr(x = data.annot, chr = "SEQNAME", bp = "GENESEQSTART", p = "P", snp = "Gene", gene = "Z_score_diff", annotation1 = "Perc_diff", annotation2 = "Alterations", logp = FALSE)
-  
+
   ##### Restrict the results to the genes of interest
-  manhattanr.res$data <- manhattanr.res$data[ manhattanr.res$data$Gene %in% data.sub$Gene, ]
-  
-  p <- manhattanly(x = data.annot, chr = "SEQNAME", bp = "GENESEQSTART", p = "P", snp = "Gene", gene = "Z_score_diff", annotation1 = "Perc_diff", annotation2 = "Alterations", suggestiveline = cn_top, genomewideline  = cn_bottom, suggestiveline_color = "gray", genomewideline_color = "gray", ylab = "CN value", showgrid = FALSE, title = "", logp = FALSE) %>%
-    
-    add_markers(y = manhattanr.res$data$P, x = manhattanr.res$data$pos, 
-                name = manhattanr.res$data$Gene,
-                text = paste0("Gene: ", manhattanr.res$data$Gene, "\nZ_score_diff: ", manhattanr.res$data$Z_score_diff, "\nPerc_diff: ", manhattanr.res$data$Perc_diff, "\nAlterations: ", manhattanr.res$data$Alterations, "\nchr: ", manhattanr.res$data$CHR),
-                mode = 'markers',
-                marker = list(size=10, symbol="circle"),
-                color = manhattanr.res$data$Gene,
-                showlegend = TRUE,
-                legendtitle=TRUE, 
-                inherit = FALSE) %>%
-    
-    add_annotations( data = manhattanr.res$data, text=~Gene,
-                      x=~pos, xanchor="left",
-                      y=~P, yanchor="top",
-                      font = list(color = "Grey", size = 10),
-                      legendtitle=TRUE,
-                      showarrow=FALSE )
-  
+  manhattanr.res$data <- manhattanr.res$data[manhattanr.res$data$Gene %in% data.sub$Gene, ]
+
+  p <- manhattanly(x = data.annot, chr = "SEQNAME", bp = "GENESEQSTART", p = "P", snp = "Gene", gene = "Z_score_diff", annotation1 = "Perc_diff", annotation2 = "Alterations", suggestiveline = cn_top, genomewideline = cn_bottom, suggestiveline_color = "gray", genomewideline_color = "gray", ylab = "CN value", showgrid = FALSE, title = "", logp = FALSE) %>%
+    add_markers(
+      y = manhattanr.res$data$P, x = manhattanr.res$data$pos,
+      name = manhattanr.res$data$Gene,
+      text = paste0("Gene: ", manhattanr.res$data$Gene, "\nZ_score_diff: ", manhattanr.res$data$Z_score_diff, "\nPerc_diff: ", manhattanr.res$data$Perc_diff, "\nAlterations: ", manhattanr.res$data$Alterations, "\nchr: ", manhattanr.res$data$CHR),
+      mode = "markers",
+      marker = list(size = 10, symbol = "circle"),
+      color = manhattanr.res$data$Gene,
+      showlegend = TRUE,
+      legendtitle = TRUE,
+      inherit = FALSE
+    ) %>%
+    add_annotations(
+      data = manhattanr.res$data, text = ~Gene,
+      x = ~pos, xanchor = "left",
+      y = ~P, yanchor = "top",
+      font = list(color = "Grey", size = 10),
+      legendtitle = TRUE,
+      showarrow = FALSE
+    )
+
   ##### Create directory for the plots
   PlotDir <- paste(results_dir, "cn_genomic_view", sep = "/")
-  if ( !file.exists(PlotDir) ) {
-    dir.create(PlotDir, recursive=TRUE)
+  if (!file.exists(PlotDir)) {
+    dir.create(PlotDir, recursive = TRUE)
   }
-  
+
   ##### Save interactive plot as html file
   saveWidgetFix(p, file = paste(PlotDir, "cn_genomic_view.html", sep = "/"))
-  
+
   #### Clear plots to free up some memory
-  if(!is.null(dev.list())) invisible(dev.off())
-  
+  if (!is.null(dev.list())) invisible(dev.off())
 } else {
   cat("None of the genes of interest are affected by changes in CN.")
   p <- NULL
@@ -3772,8 +3688,8 @@ if ( nrow(data.annot) > 0 ) {
 p
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:manhattanly", unload=FALSE)
-detach("package:plotly", unload=FALSE)
+detach("package:manhattanly", unload = FALSE)
+detach("package:plotly", unload = FALSE)
 ```
 
 ***
@@ -3790,16 +3706,16 @@ cn_dist_plot
 
 ##### Create directory for the plots
 PlotDir <- paste(results_dir, "cn_dist_plot", sep = "/")
-if ( !file.exists(PlotDir) ) {
-  dir.create(PlotDir, recursive=TRUE)
+if (!file.exists(PlotDir)) {
+  dir.create(PlotDir, recursive = TRUE)
 }
 
 ##### Save interactive plot as html file
 saveWidgetFix(cn_dist_plot, file = paste(PlotDir, "cn_dist_plot.html", sep = "/"))
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 </details>
@@ -3817,23 +3733,21 @@ Scatterplot comparing the per-gene difference in **mRNA expression** of [Cancer 
 suppressMessages(library(plotly))
 cn_genes <- data.sub$Gene
 
-if ( runPcgrChunk && length(cn_genes) > 0 ) {
+if (runPcgrChunk && length(cn_genes) > 0) {
   mutCNexprPlot(data = data.sub, alt_data = TRUE, cn_bottom = cn_bottom, cn_top = cn_top, comp_cancer = comp_cancer_group, type = "perc", report_dir = results_dir)
-  
-} else if ( length(cn_genes) > 0) {
-  data.sub <- data.sub[ data.sub$Gene %in% cn_genes, ]
+} else if (length(cn_genes) > 0) {
+  data.sub <- data.sub[data.sub$Gene %in% cn_genes, ]
   mutCNexprPlot(data = data.sub, alt_data = FALSE, cn_bottom = cn_bottom, cn_top = cn_top, comp_cancer = comp_cancer_group, type = "perc", report_dir = results_dir)
-  
 } else {
   cn_genes <- NULL
   cat("None of the genes of interest are affected by changes in CN.")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 ***
@@ -3844,24 +3758,22 @@ if(!is.null(dev.list())) invisible(dev.off())
 ##### Generate scatterplot with per-gene expression values (y-axis), CN values (x-axis) and mutation status info (colours)
 suppressMessages(library(plotly))
 
-if ( runPcgrChunk && length(cn_genes) > 0 ) {
-  data.sub <- data.sub[ data.sub$Gene %in% cn_genes, ]
+if (runPcgrChunk && length(cn_genes) > 0) {
+  data.sub <- data.sub[data.sub$Gene %in% cn_genes, ]
   mutCNexprPlot(data = data.sub, alt_data = TRUE, cn_bottom = cn_bottom, cn_top = cn_top, comp_cancer = comp_cancer_group, type = "z", report_dir = results_dir)
-  
-} else if ( length(cn_genes) > 0) {
-  data.sub <- data.sub[ data.sub$Gene %in% cn_genes, ]
+} else if (length(cn_genes) > 0) {
+  data.sub <- data.sub[data.sub$Gene %in% cn_genes, ]
   mutCNexprPlot(data = data.sub, alt_data = FALSE, cn_bottom = cn_bottom, cn_top = cn_top, comp_cancer = comp_cancer_group, type = "z", report_dir = results_dir)
-  
 } else {
   cn_genes <- NULL
   cat("None of the genes of interest are affected by changes in CN.")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 ***
@@ -3880,15 +3792,15 @@ Table summarising the **mRNA expression** values in cancer and patient samples f
 ##### Generate expression summary table for per-gene expression values CN values and mutation status info (colours)
 ##### Keep only genes within CN gains
 cn_data <- ref_dataset.list[[dataset]][["expr_mut_cn_data"]]
-cn_data <- cn_data[ cn_data$CN >= cn_top, ]
-cn_data <- cn_data[, "CN", drop=FALSE]
-genes_gains = as.character(cn_genes[ cn_genes %in% rownames(cn_data) ])
+cn_data <- cn_data[cn_data$CN >= cn_top, ]
+cn_data <- cn_data[, "CN", drop = FALSE]
+genes_gains <- as.character(cn_genes[cn_genes %in% rownames(cn_data)])
 
 ##### Deal with no genes
-if ( length(genes_gains) == 0 ) {
+if (length(genes_gains) == 0) {
   genes_gains <- NULL
   genes_gains_no <- 0
-} else if ( length(genes_gains) > params$top_genes ) {
+} else if (length(genes_gains) > params$top_genes) {
   genes_gains_no <- params$top_genes
 } else {
   genes_gains_no <- length(genes_gains)
@@ -3897,20 +3809,20 @@ if ( length(genes_gains) == 0 ) {
 ##### Get expression data
 data <- ref_dataset.list[[dataset]][["data_to_report"]]
 
-if ( runPcgrChunk && runPurpleChunk ) {
-  cn_expr_genes.expr.gains.perc <- exprTable( genes = genes_gains, data = data, cn_data = cn_data, cn_decrease = TRUE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
-  
-##### Generate expression summary table for per-gene expression values and CN values
-} else if ( runPurpleChunk ) {
-  cn_expr_genes.expr.gains.perc <- exprTable( genes = genes_gains, data = data, cn_data = cn_data, cn_decrease = TRUE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+if (runPcgrChunk && runPurpleChunk) {
+  cn_expr_genes.expr.gains.perc <- exprTable(genes = genes_gains, data = data, cn_data = cn_data, cn_decrease = TRUE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+
+  ##### Generate expression summary table for per-gene expression values and CN values
+} else if (runPurpleChunk) {
+  cn_expr_genes.expr.gains.perc <- exprTable(genes = genes_gains, data = data, cn_data = cn_data, cn_decrease = TRUE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 }
-  
+
 ##### Present the expression, CN and mutation data summary table
 cn_expr_genes.expr.gains.perc[[1]]
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=cn_expr_genes.expr.gains.perc[[1]], file=paste(exprTableDir, "cn_expr_genes.expr.gains.perc.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = cn_expr_genes.expr.gains.perc[[1]], file = paste(exprTableDir, "cn_expr_genes.expr.gains.perc.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -3931,20 +3843,20 @@ The <span style="color:#ff0000">RED</span> colour range indicate relatively **hi
 
 ```{r cn_expr_data_table_gains, comment = NA, message=FALSE, warning=FALSE, fig.width = 8, fig.height = 3, eval = runPurpleChunk}
 ##### Generate expression summary table for per-gene expression values CN values and mutation status info (colours)
-if ( runPcgrChunk && runPurpleChunk ) {
-  cn_expr_genes.expr.gains.z <- exprTable( genes = genes_gains, data = data, cn_data = cn_data, cn_decrease = TRUE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
-  
-##### Generate expression summary table for per-gene expression values and CN values
-} else if ( runPurpleChunk ) {
-  cn_expr_genes.expr.gains.z <- exprTable( genes = genes_gains, data = data, cn_data = cn_data, cn_decrease = TRUE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+if (runPcgrChunk && runPurpleChunk) {
+  cn_expr_genes.expr.gains.z <- exprTable(genes = genes_gains, data = data, cn_data = cn_data, cn_decrease = TRUE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+
+  ##### Generate expression summary table for per-gene expression values and CN values
+} else if (runPurpleChunk) {
+  cn_expr_genes.expr.gains.z <- exprTable(genes = genes_gains, data = data, cn_data = cn_data, cn_decrease = TRUE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 }
-  
+
 ##### Present the expression, CN and mutation data summary table
 cn_expr_genes.expr.gains.z[[1]]
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=cn_expr_genes.expr.gains.z[[1]], file=paste(exprTableDir, "cn_expr_genes.expr.gains.z.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = cn_expr_genes.expr.gains.z[[1]], file = paste(exprTableDir, "cn_expr_genes.expr.gains.z.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space
@@ -3974,21 +3886,21 @@ Table summarising the **mRNA expression** values in cancer and patient samples f
 ##### Generate expression summary table for per-gene expression values CN values and mutation status info (colours)
 ##### Keep only genes within CN losses
 cn_data <- ref_dataset.list[[dataset]][["expr_mut_cn_data"]]
-cn_data <- cn_data[ cn_data$CN <= cn_bottom, ]
-cn_data <- cn_data[, "CN", drop=FALSE]
-genes_losses = as.character(cn_genes[ cn_genes %in% rownames(cn_data) ])
+cn_data <- cn_data[cn_data$CN <= cn_bottom, ]
+cn_data <- cn_data[, "CN", drop = FALSE]
+genes_losses <- as.character(cn_genes[cn_genes %in% rownames(cn_data)])
 
 ##### Deal with no genes or when more than 10 genes are of interest
-if ( length(genes_losses) == 0 ) {
+if (length(genes_losses) == 0) {
   genes_losses <- NULL
   genes_losses_no <- 0
-} else if ( length(genes_losses) > params$top_genes ) {
+} else if (length(genes_losses) > params$top_genes) {
   genes_losses_no <- params$top_genes
 } else {
   genes_losses_no <- length(genes_losses)
 }
-  
-if ( genes_gains_no + genes_losses_no > params$top_genes ) {
+
+if (genes_gains_no + genes_losses_no > params$top_genes) {
   limit_genes <- TRUE
 } else {
   limit_genes <- FALSE
@@ -3997,20 +3909,20 @@ if ( genes_gains_no + genes_losses_no > params$top_genes ) {
 ##### Get expression data
 data <- ref_dataset.list[[dataset]][["data_to_report"]]
 
-if ( runPcgrChunk && runPurpleChunk ) {
-  cn_expr_genes.expr.losses.perc <- exprTable( genes = genes_losses, data = data, cn_data = cn_data, cn_decrease = FALSE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
-  
-##### Generate expression summary table for per-gene expression values and CN values
-} else if ( runPurpleChunk ) {
-  cn_expr_genes.expr.losses.perc <- exprTable( genes = genes_losses, data = data, cn_data = cn_data, cn_decrease = FALSE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+if (runPcgrChunk && runPurpleChunk) {
+  cn_expr_genes.expr.losses.perc <- exprTable(genes = genes_losses, data = data, cn_data = cn_data, cn_decrease = FALSE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+
+  ##### Generate expression summary table for per-gene expression values and CN values
+} else if (runPurpleChunk) {
+  cn_expr_genes.expr.losses.perc <- exprTable(genes = genes_losses, data = data, cn_data = cn_data, cn_decrease = FALSE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 }
-  
+
 ##### Present the expression, CN and mutation data summary table
 cn_expr_genes.expr.losses.perc[[1]]
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=cn_expr_genes.expr.losses.perc[[1]], file=paste(exprTableDir, "cn_expr_genes.expr.losses.perc.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = cn_expr_genes.expr.losses.perc[[1]], file = paste(exprTableDir, "cn_expr_genes.expr.losses.perc.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4031,20 +3943,20 @@ The <span style="color:#ff0000">RED</span> colour range indicate relatively **hi
 
 ```{r cn_expr_data_table_losses, comment = NA, message=FALSE, warning=FALSE, eval = runPurpleChunk}
 ##### Generate expression summary table for per-gene expression values CN values and mutation status info (colours)
-if ( runPcgrChunk && runPurpleChunk ) {
-  cn_expr_genes.expr.losses.z <- exprTable( genes = genes_losses, data = data, cn_data = cn_data, cn_decrease = FALSE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
-  
-##### Generate expression summary table for per-gene expression values and CN values
-} else if ( runPurpleChunk ) {
-  cn_expr_genes.expr.losses.z <- exprTable( genes = genes_losses, data = data, cn_data = cn_data, cn_decrease = FALSE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline") ], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+if (runPcgrChunk && runPurpleChunk) {
+  cn_expr_genes.expr.losses.z <- exprTable(genes = genes_losses, data = data, cn_data = cn_data, cn_decrease = FALSE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], mut_annot = ref_genes.list[["pcgr"]][, c("SYMBOL", "TIER", "CONSEQUENCE", "VARIANT_CLASS", "AF_TUMOR", "GENOMIC_CHANGE", "PROTEIN_CHANGE")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+
+  ##### Generate expression summary table for per-gene expression values and CN values
+} else if (runPurpleChunk) {
+  cn_expr_genes.expr.losses.z <- exprTable(genes = genes_losses, data = data, cn_data = cn_data, cn_decrease = FALSE, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]][, c("Oncogene", "TSG", "Fusion", "Germline")], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 }
-  
+
 ##### Present the expression, CN and mutation data summary table
 cn_expr_genes.expr.losses.z[[1]]
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=cn_expr_genes.expr.losses.z[[1]], file=paste(exprTableDir, "cn_expr_genes.expr.losses.z.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = cn_expr_genes.expr.losses.z[[1]], file = paste(exprTableDir, "cn_expr_genes.expr.losses.z.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space and return output
@@ -4078,28 +3990,27 @@ output_counts <- list()
 output_density <- list()
 genes <- cn_expr_genes.expr.gains.perc[[2]]$SYMBOL
 
-##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample 
-for( i in 1:genes_gains_no ) {
-  if ( genes_gains_no > 0 && genes[i] %in% rownames(data) ) {
-    
+##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample
+for (i in 1:genes_gains_no) {
+  if (genes_gains_no > 0 && genes[i] %in% rownames(data)) {
     ##### CDF plot
     output_cdf[[i]] <- cdfPlot(gene = genes[i], data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, addBoxPlot = TRUE, scaling = scaling, report_dir = results_dir)
-    
+
     ##### Bar-plot of read counts
     ##### First map the gene symbol to Ensmebl ID (used in the counts data)
-    genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL ==  genes[i] ]
-    
-    output_counts[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group )
-    
+    genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL == genes[i]]
+
+    output_counts[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group)
+
     ##### Density plot - expression distribution
-    output_density[[i]] <- densityPlot(gene = genes[i], data = data, main_title= "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling) 
+    output_density[[i]] <- densityPlot(gene = genes[i], data = data, main_title = "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling)
   }
 }
 
 ##### Now once the plots are ready show them in separate tabs
-if ( genes_gains_no != 0 ) {
-  for( i in 1:genes_gains_no ){
-    if ( genes[i] %in% rownames(data) ) {
+if (genes_gains_no != 0) {
+  for (i in 1:genes_gains_no) {
+    if (genes[i] %in% rownames(data)) {
       cat("\n##### ", genes[i], "\n")
       cat(renderTags(output_cdf[[i]])$html)
       cat("\n<details>\n")
@@ -4130,18 +4041,18 @@ if ( genes_gains_no != 0 ) {
       cat("\n***\n")
     }
     #### Clear plots to free up some memory
-    if(!is.null(dev.list())) invisible(dev.off())
+    if (!is.null(dev.list())) invisible(dev.off())
   }
 } else {
   cat("\nNo alterations were reported.\n")
-   cat("\n***\n")
+  cat("\n***\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 ##### Clean the space
-rm(list = ls(pattern='^output*'))
+rm(list = ls(pattern = "^output*"))
 ```
 
 ***
@@ -4156,28 +4067,27 @@ output_counts <- list()
 output_density <- list()
 genes <- cn_expr_genes.expr.losses.perc[[2]]$SYMBOL
 
-##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample 
-for( i in 1:genes_losses_no ) {
-  if ( genes_losses_no > 0 && genes[i] %in% rownames(data) ) {
-    
+##### For each gene generate (1) CDF plot and add boxplot below to show the data variance for selected gene in individual groups, (2) bar-plot of read count data across all samples and (3) density plot to demonstrate expression distribution in investigated sample
+for (i in 1:genes_losses_no) {
+  if (genes_losses_no > 0 && genes[i] %in% rownames(data)) {
     ##### CDF plot
     output_cdf[[i]] <- cdfPlot(gene = genes[i], data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, addBoxPlot = TRUE, scaling = scaling, report_dir = results_dir)
-    
+
     ##### Bar-plot of read counts
     ##### First map the gene symbol to Ensmebl ID (used in the counts data)
-    genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL ==  genes[i] ]
-    
-    output_counts[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group )
-    
+    genes.ENSEMBL <- ref_dataset.list[[dataset]][["gene_annot_all"]]$ENSEMBL[ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL == genes[i]]
+
+    output_counts[[i]] <- barPlot(gene = genes.ENSEMBL, data = ref_dataset.list[[dataset]][["combined_data"]], y_title = "Counts", targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, add_cancer = add_cancer_group)
+
     ##### Density plot - expression distribution
-    output_density[[i]] <- densityPlot(gene = genes[i], data = data, main_title= "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling)
+    output_density[[i]] <- densityPlot(gene = genes[i], data = data, main_title = "", x_title = "Z-score", sampleName = sample_name, distributions = c("normal", "bimodal"), scaling = scaling)
   }
 }
 
 ##### Now once the plots are ready show them in separate tabs
-if ( genes_losses_no != 0 ) {
-  for( i in 1:genes_losses_no ){
-    if ( genes[i] %in% rownames(data) ) {
+if (genes_losses_no != 0) {
+  for (i in 1:genes_losses_no) {
+    if (genes[i] %in% rownames(data)) {
       cat("\n##### ", genes[i], "\n")
       cat(renderTags(output_cdf[[i]])$html)
       cat("\n<details>\n")
@@ -4209,18 +4119,17 @@ if ( genes_losses_no != 0 ) {
     }
   }
   #### Clear plots to free up some memory
-  if(!is.null(dev.list())) invisible(dev.off())
-  
+  if (!is.null(dev.list())) invisible(dev.off())
 } else {
   cat("\nNo alterations were reported.\n")
-   cat("\n***\n")
+  cat("\n***\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 ##### Clean the space
-rm(list = ls(pattern='^output*'))
+rm(list = ls(pattern = "^output*"))
 rm(limit_genes)
 ```
 
@@ -4247,18 +4156,18 @@ data <- ref_dataset.list[[dataset]][["data_to_report"]]
 genes <- unique(unlist(ref_genes.list[["genes_immune"]]$immune_markers$SYMBOL))
 
 ##### Deal with no genes or when more than 10 genes are of interest
-if ( length(genes) == 0 ) {
+if (length(genes) == 0) {
   genes <- NULL
 }
 
-immune_genes.expr.perc <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL", "Immune_Cycle_Role")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
+immune_genes.expr.perc <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL", "Immune_Cycle_Role")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
 
 ##### Present the expression summary table
 immune_genes.expr.perc
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=immune_genes.expr.perc, file=paste(exprTableDir, "immune_genes.expr.perc.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = immune_genes.expr.perc, file = paste(exprTableDir, "immune_genes.expr.perc.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space
@@ -4280,14 +4189,14 @@ The <span style="color:#ff0000">RED</span> colour range indicate relatively **hi
 
 ```{r immune_genes_table, comment = NA, message=FALSE, warning=FALSE}
 ##### Generate expression summary table for cancer genes from OncoKB and UMCCR (https://github.com/vladsaveliev/NGS_Utils/blob/master/ngs_utils/reference_data/key_genes/umccr_cancer_genes.2019-03-20.tsv)
-immune_genes.expr.z <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL", "Immune_Cycle_Role")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
+immune_genes.expr.z <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL", "Immune_Cycle_Role")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
 
 ##### Present the expression summary table
 immune_genes.expr.z
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=immune_genes.expr.z, file=paste(exprTableDir, "immune_genes.expr.z.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = immune_genes.expr.z, file = paste(exprTableDir, "immune_genes.expr.z.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space
@@ -4315,17 +4224,17 @@ Overview of immune markers expression profiles in patient's sample and in sample
 suppressMessages(library(plotly))
 
 ##### Generate overview boxplot
-if ( !is.null(genes) ) {
+if (!is.null(genes)) {
   glanceExprPlot(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, hexcode = "immune_genes", type = "perc", sort = "alphabetically", scaling = scaling, report_dir = results_dir)
 } else {
   cat("\nNo expression data is available for immune markers!\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 <details>
@@ -4345,17 +4254,17 @@ The individual box(es) represent the `r if ( int_cancer_group == comp_cancer_gro
 suppressMessages(library(plotly))
 
 ##### Generate overview boxplot
-if ( !is.null(genes) ) {
+if (!is.null(genes)) {
   glanceExprPlot(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, hexcode = "immune_genes", type = "z", sort = "alphabetically", scaling = scaling, report_dir = results_dir)
 } else {
   cat("\nNo expression data is available for immune markers!\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 <details>
@@ -4386,13 +4295,13 @@ The individual box(es) represent the `r if ( int_cancer_group == comp_cancer_gro
 webplot(as.data.frame(ref_genes.list[["genes_immune"]]$immunogram.df), data.row = ncol(data), main = "", add = FALSE, col = "black")
 
 ##### Now add data for samples with specific immunogram patterns, e.g. T-cell–rich, T-cell–poor, T-cell–intermediate...
-#webplot(as.data.frame(ref_genes.list[["genes_immune"]]$immunogram.df), data.row = 5, main = "", add = TRUE, col = "powderblue", lty = 5)
-#webplot(as.data.frame(ref_genes.list[["genes_immune"]]$immunogram.df), data.row = 156, main = "", add = TRUE, col = "forestgreen", lty = 5)
-#webplot(as.data.frame(ref_genes.list[["genes_immune"]]$immunogram.df), data.row = 194, main = "", add = TRUE, col = "red", lty = 5)
-#legend("topright", legend=c("Patient", "T-cell–rich","T-cell–poor", "T-cell–intermediate"), fill=c("black", "powderblue", "forestgreen", "red"), bty="n", bg = "transparent", cex = 0.8)
+# webplot(as.data.frame(ref_genes.list[["genes_immune"]]$immunogram.df), data.row = 5, main = "", add = TRUE, col = "powderblue", lty = 5)
+# webplot(as.data.frame(ref_genes.list[["genes_immune"]]$immunogram.df), data.row = 156, main = "", add = TRUE, col = "forestgreen", lty = 5)
+# webplot(as.data.frame(ref_genes.list[["genes_immune"]]$immunogram.df), data.row = 194, main = "", add = TRUE, col = "red", lty = 5)
+# legend("topright", legend=c("Patient", "T-cell–rich","T-cell–poor", "T-cell–intermediate"), fill=c("black", "powderblue", "forestgreen", "red"), bty="n", bg = "transparent", cex = 0.8)
 
 #### Clear plots to free up some memory
-#if(!is.null(dev.list())) invisible(dev.off())
+# if(!is.null(dev.list())) invisible(dev.off())
 ```
 
 `r if ( params$immunogram ) { c("***") }`
@@ -4417,19 +4326,19 @@ data <- ref_dataset.list[[dataset]][["data_to_report"]]
 genes <- unique(unlist(ref_genes.list[["genes_immune"]]$immunogram$SYMBOL))
 
 ##### Deal with no genes or when more than 10 genes are of interest
-if ( length(genes) == 0 ) {
+if (length(genes) == 0) {
   genes <- NULL
 }
 
 ##### Generate expression summary table for cancer genes from OncoKB and UMCCr (https://github.com/vladsaveliev/NGS_Utils/blob/master/ngs_utils/reference_data/key_genes/umccr_cancer_genes.2019-03-20.tsv)
-immunogram.expr.perc <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL", "CIC")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
+immunogram.expr.perc <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL", "CIC")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
 
 ##### Present the expression summary table
 immunogram.expr.perc
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=immunogram.expr.perc, file=paste(exprTableDir, "immunogram.expr.perc.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = immunogram.expr.perc, file = paste(exprTableDir, "immunogram.expr.perc.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space
@@ -4450,14 +4359,14 @@ cat("\n***\n")
 
 ```{r immunogram_table, comment = NA, message=FALSE, warning=FALSE, eval = params$immunogram}
 ##### Generate expression summary table for cancer genes from OncoKB and UMCCR (https://github.com/vladsaveliev/NGS_Utils/blob/master/ngs_utils/reference_data/key_genes/umccr_cancer_genes.2019-03-20.tsv)
-immunogram.expr.z <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL", "CIC")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
+immunogram.expr.z <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL", "CIC")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
 
 ##### Present the expression summary table
 immunogram.expr.z
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=immunogram.expr.z, file=paste(exprTableDir, "immunogram.expr.z.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = immunogram.expr.z, file = paste(exprTableDir, "immunogram.expr.z.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4482,18 +4391,18 @@ data <- ref_dataset.list[[dataset]][["data_to_report"]]
 genes <- unique(unlist(ref_genes.list[["genes_hrd"]]$SYMBOL))
 
 ##### Deal with no genes
-if ( length(genes) == 0 ) {
+if (length(genes) == 0) {
   genes <- NULL
 }
 
-hrd_genes.expr.perc <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+hrd_genes.expr.perc <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 
 ##### Present the expression summary table
 hrd_genes.expr.perc[[1]]
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=hrd_genes.expr.perc[[1]], file=paste(exprTableDir, "hrd_genes.expr.perc.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = hrd_genes.expr.perc[[1]], file = paste(exprTableDir, "hrd_genes.expr.perc.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4512,14 +4421,14 @@ The <span style="color:#ff0000">RED</span> colour range indicate relatively **hi
 
 ```{r hrd_genes_table, comment = NA, message=FALSE, warning=FALSE}
 ##### Generate expression summary table for hrd genes from Richard
-hrd_genes.expr.z <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+hrd_genes.expr.z <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 
 ##### Present the expression summary table
 hrd_genes.expr.z[[1]]
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=hrd_genes.expr.z[[1]], file=paste(exprTableDir, "hrd_genes.expr.z.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = hrd_genes.expr.z[[1]], file = paste(exprTableDir, "hrd_genes.expr.z.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space
@@ -4547,17 +4456,17 @@ Overview of HRD genes expression profiles in patient's sample and in samples fro
 suppressMessages(library(plotly))
 
 ##### Generate overview boxplot
-if ( !is.null(genes) ) {
+if (!is.null(genes)) {
   glanceExprPlot(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, hexcode = "hrd_genes", type = "perc", sort = "alphabetically", scaling = scaling, report_dir = results_dir)
 } else {
   cat("\nNo expression data is available for HRD genes!\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 <details>
@@ -4577,17 +4486,17 @@ The individual box(es) represent the `r if ( int_cancer_group == comp_cancer_gro
 suppressMessages(library(plotly))
 
 ##### Generate overview boxplot
-if ( !is.null(genes) ) {
+if (!is.null(genes)) {
   glanceExprPlot(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, hexcode = "hrd_genes", type = "z", sort = "alphabetically", scaling = scaling, report_dir = results_dir)
 } else {
   cat("\nNo expression data is available for HRD genes!\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 <details>
@@ -4622,18 +4531,18 @@ data <- ref_dataset.list[[dataset]][["data_to_report"]]
 genes <- rownames(ref_genes.list[["genes_cancer"]])
 
 ##### Deal with no genes
-if ( length(genes) == 0 ) {
+if (length(genes) == 0) {
   genes <- NULL
 }
 
-cancer_genes.expr.perc <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
+cancer_genes.expr.perc <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]], ext_links = TRUE, type = "perc", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)
 
 ##### Present the expression summary table
 cancer_genes.expr.perc[[1]]
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=cancer_genes.expr.perc[[1]], file=paste(exprTableDir, "cancer_genes.expr.perc.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = cancer_genes.expr.perc[[1]], file = paste(exprTableDir, "cancer_genes.expr.perc.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4652,14 +4561,14 @@ The <span style="color:#ff0000">RED</span> colour range indicate relatively **hi
 
 ```{r cancer_genes_table, comment = NA, message=FALSE, warning=FALSE}
 ##### Generate expression summary table for cancer genes from OncoKB and UMCCR (https://github.com/vladsaveliev/NGS_Utils/blob/master/ngs_utils/reference_data/key_genes/umccr_cancer_genes.2019-03-20.tsv)
-cancer_genes.expr.z <- exprTable( genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
+cancer_genes.expr.z <- exprTable(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, genes_annot = ref_dataset.list[[dataset]][["gene_annot_all"]][, c("SYMBOL", "ENSEMBL")], oncokb_annot = ref_genes.list[["genes_oncokb"]], cancer_genes = ref_genes.list[["genes_cancer"]], ext_links = TRUE, type = "z", scaling = scaling, caner_genes_annot.list = caner_genes_annot.list)[[1]]
 
 ##### Present the expression summary table
 cancer_genes.expr.z
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=cancer_genes.expr.z, file=paste(exprTableDir, "cancer_genes.expr.z.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = cancer_genes.expr.z, file = paste(exprTableDir, "cancer_genes.expr.z.html", sep = "/"), selfcontained = TRUE)
 }
 
 ##### Clean the space
@@ -4689,17 +4598,17 @@ suppressMessages(library(plotly))
 ##### Generate overview boxplot
 genes <- cancer_genes.expr.perc[[2]]$SYMBOL[1:50]
 
-if ( !is.null(genes) ) {
+if (!is.null(genes)) {
   glanceExprPlot(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, hexcode = "cancer_genes", type = "perc", sort = "none", scaling = scaling, report_dir = results_dir)
 } else {
   cat("\nNo expression data is available for cancer genes!\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 <details>
@@ -4718,17 +4627,17 @@ The individual box(es) represent the `r if ( int_cancer_group == comp_cancer_gro
 ```{r glance_expr_plot_cancer_genes, comment = NA, message=FALSE, warning=FALSE, fig.width = 8, fig.height = 3}
 suppressMessages(library(plotly))
 
-if ( !is.null(genes) ) {
+if (!is.null(genes)) {
   glanceExprPlot(genes = genes, data = data, targets = targets, sampleName = sample_name, ext_cancer = ext_cancer_group, int_cancer = int_cancer_group, comp_cancer = comp_cancer_group, add_cancer = add_cancer_group, hexcode = "cancer_genes", type = "z", sort = "none", scaling = scaling, report_dir = results_dir)
 } else {
   cat("\nNo expression data is available for cancer genes!\n")
 }
 
 ##### Detach plotly package. Otherwise it clashes with other graphics devices
-detach("package:plotly", unload=FALSE)
+detach("package:plotly", unload = FALSE)
 
 #### Clear plots to free up some memory
-if(!is.null(dev.list())) invisible(dev.off())
+if (!is.null(dev.list())) invisible(dev.off())
 ```
 
 <details>
@@ -4749,8 +4658,8 @@ The individual box(es) represent the `r if ( int_cancer_group == comp_cancer_gro
 ```{r drugs_table_dir, comment = NA, message=FALSE, warning=FALSE}
 ##### Create directory for tables
 drugsTableDir <- paste(results_dir, "drugsTables", sep = "/")
-if ( !file.exists(drugsTableDir) ) {
-  dir.create(drugsTableDir, recursive=TRUE)
+if (!file.exists(drugsTableDir)) {
+  dir.create(drugsTableDir, recursive = TRUE)
 }
 ```
 
@@ -4764,15 +4673,15 @@ if ( !file.exists(drugsTableDir) ) {
 ##### Generate table with drugs targeting mutated cancer genes
 genes <- mut_genes.expr.perc[[2]]$SYMBOL
 
-drugsTable.mut_genes <- civicDrugTable(genes, civic_var_summaries = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid = caner_genes_annot.list[["civic_clin_evid"]],  evid_type = "Predictive", var_type = "mutation")
+drugsTable.mut_genes <- civicDrugTable(genes, civic_var_summaries = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid = caner_genes_annot.list[["civic_clin_evid"]], evid_type = "Predictive", var_type = "mutation")
 
-if ( params$drugs ) {
+if (params$drugs) {
   drugsTable.mut_genes[[1]]
 }
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=drugsTable.mut_genes[[1]], file=paste(drugsTableDir, "drugsTable.mut_genes.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = drugsTable.mut_genes[[1]], file = paste(drugsTableDir, "drugsTable.mut_genes.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4814,18 +4723,18 @@ cat(drugsTable_legend)
 
 ```{r drugs_predictive_fusion_genes, comment = NA, message=FALSE, warning=FALSE, eval = runFusionChunk}
 ##### Generate table with drugs targeting fusion genes
-genesA <- as.vector(fusions[ fusion_annot$reported_fusion == "Yes" | fusion_annot$geneA_dna_support == "Yes" | fusion_annot$geneB_dna_support == "Yes", ]$geneA)
-genesB <- as.vector(fusions[ fusion_annot$reported_fusion == "Yes" | fusion_annot$geneA_dna_support == "Yes" | fusion_annot$geneB_dna_support == "Yes", ]$geneB)
+genesA <- as.vector(fusions[fusion_annot$reported_fusion == "Yes" | fusion_annot$geneA_dna_support == "Yes" | fusion_annot$geneB_dna_support == "Yes", ]$geneA)
+genesB <- as.vector(fusions[fusion_annot$reported_fusion == "Yes" | fusion_annot$geneA_dna_support == "Yes" | fusion_annot$geneB_dna_support == "Yes", ]$geneB)
 
-drugsTable.fusion_genes <- civicDrugTable(genes = unique(c(genesA, genesB)), civic_var_summaries  = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid  = caner_genes_annot.list[["civic_clin_evid"]],  evid_type = "Predictive", var_type = "fusion")
+drugsTable.fusion_genes <- civicDrugTable(genes = unique(c(genesA, genesB)), civic_var_summaries = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid = caner_genes_annot.list[["civic_clin_evid"]], evid_type = "Predictive", var_type = "fusion")
 
-if ( params$drugs ) {
+if (params$drugs) {
   drugsTable.fusion_genes[[1]]
 }
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=drugsTable.fusion_genes[[1]], file=paste(drugsTableDir, "drugsTable.fusion_genes.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = drugsTable.fusion_genes[[1]], file = paste(drugsTableDir, "drugsTable.fusion_genes.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4849,15 +4758,15 @@ cat(drugsTable_legend)
 ##### Generate table with drugs targeting dysregulated cancer genes
 genes <- unique(manta_sv$Gene)
 
-drugsTable.sv_genes <- civicDrugTable(genes, civic_var_summaries  = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid  = caner_genes_annot.list[["civic_clin_evid"]],  evid_type = "Predictive", var_type = NULL)
+drugsTable.sv_genes <- civicDrugTable(genes, civic_var_summaries = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid = caner_genes_annot.list[["civic_clin_evid"]], evid_type = "Predictive", var_type = NULL)
 
-if ( params$drugs ) {
+if (params$drugs) {
   drugsTable.sv_genes[[1]]
 }
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=drugsTable.sv_genes[[1]], file=paste(drugsTableDir, "drugsTable.sv_genes.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = drugsTable.sv_genes[[1]], file = paste(drugsTableDir, "drugsTable.sv_genes.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4883,15 +4792,15 @@ cat(drugsTable_legend)
 ##### Generate table with drugs targeting CN altered genes
 genes <- cn_expr_genes.expr.gains.perc[[2]]$SYMBOL
 
-drugsTable.CN_altered_genes_gains <- civicDrugTable(genes, civic_var_summaries  = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid  = caner_genes_annot.list[["civic_clin_evid"]],  evid_type = "Predictive", var_type = "copy_gain")
+drugsTable.CN_altered_genes_gains <- civicDrugTable(genes, civic_var_summaries = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid = caner_genes_annot.list[["civic_clin_evid"]], evid_type = "Predictive", var_type = "copy_gain")
 
-if ( params$drugs ) {
+if (params$drugs) {
   drugsTable.CN_altered_genes_gains[[1]]
 }
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=drugsTable.CN_altered_genes_gains[[1]], file=paste(drugsTableDir, "drugsTable.CN_altered_genes_gains.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = drugsTable.CN_altered_genes_gains[[1]], file = paste(drugsTableDir, "drugsTable.CN_altered_genes_gains.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4911,15 +4820,15 @@ cat(drugsTable_legend)
 ##### Generate table with drugs targeting CN altered genes
 genes <- cn_expr_genes.expr.losses.perc[[2]]$SYMBOL
 
-drugsTable.CN_altered_genes_losses <- civicDrugTable(genes, civic_var_summaries  = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid  = caner_genes_annot.list[["civic_clin_evid"]],  evid_type = "Predictive", var_type = "copy_loss")
+drugsTable.CN_altered_genes_losses <- civicDrugTable(genes, civic_var_summaries = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid = caner_genes_annot.list[["civic_clin_evid"]], evid_type = "Predictive", var_type = "copy_loss")
 
-if ( params$drugs ) {
+if (params$drugs) {
   drugsTable.CN_altered_genes_losses[[1]]
 }
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=drugsTable.CN_altered_genes_losses[[1]], file=paste(drugsTableDir, "drugsTable.CN_altered_genes_losses.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = drugsTable.CN_altered_genes_losses[[1]], file = paste(drugsTableDir, "drugsTable.CN_altered_genes_losses.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4939,17 +4848,17 @@ cat(drugsTable_legend)
 
 ```{r drugs_predictive_hrd_genes, comment = NA, message=FALSE, warning=FALSE}
 ##### Generate table with drugs targeting mutated cancer genes
-genes <- hrd_genes.expr.perc[[2]]$SYMBOL[ hrd_genes.expr.perc[[2]]$SYMBOL %in% rownames(ref_dataset.list[[dataset]][["data_to_report"]]) ]
+genes <- hrd_genes.expr.perc[[2]]$SYMBOL[hrd_genes.expr.perc[[2]]$SYMBOL %in% rownames(ref_dataset.list[[dataset]][["data_to_report"]])]
 
-drugsTable.hrd_genes <- civicDrugTable(genes, civic_var_summaries = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid = caner_genes_annot.list[["civic_clin_evid"]],  evid_type = "Predictive", var_type = "mutation")
+drugsTable.hrd_genes <- civicDrugTable(genes, civic_var_summaries = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid = caner_genes_annot.list[["civic_clin_evid"]], evid_type = "Predictive", var_type = "mutation")
 
-if ( params$drugs ) {
+if (params$drugs) {
   drugsTable.hrd_genes[[1]]
 }
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=drugsTable.hrd_genes[[1]], file=paste(drugsTableDir, "drugsTable.hrd_genes.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = drugsTable.hrd_genes[[1]], file = paste(drugsTableDir, "drugsTable.hrd_genes.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -4975,15 +4884,15 @@ mysql_populate_update <- paste0(mysql_populate_update, ",Drug matching")
 ##### Generate table with drugs targeting dysregulated cancer genes
 genes <- cancer_genes.expr.perc[[2]]$SYMBOL[1:50]
 
-drugsTable.cancer_genes <- civicDrugTable(genes, civic_var_summaries  = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid  = caner_genes_annot.list[["civic_clin_evid"]],  evid_type = "Predictive", var_type = "expression")
+drugsTable.cancer_genes <- civicDrugTable(genes, civic_var_summaries = caner_genes_annot.list[["civic_var_summaries"]], civic_clin_evid = caner_genes_annot.list[["civic_clin_evid"]], evid_type = "Predictive", var_type = "expression")
 
-if ( params$drugs ) {
+if (params$drugs) {
   drugsTable.cancer_genes[[1]]
 }
 
 ##### Save the expression table as html file
-if ( params$save_tables ) {
-  saveWidgetFix(widget=drugsTable.cancer_genes[[1]], file=paste(drugsTableDir, "drugsTable.cancer_genes.html", sep = "/"), selfcontained=TRUE)
+if (params$save_tables) {
+  saveWidgetFix(widget = drugsTable.cancer_genes[[1]], file = paste(drugsTableDir, "drugsTable.cancer_genes.html", sep = "/"), selfcontained = TRUE)
 }
 ```
 
@@ -5004,7 +4913,7 @@ mysql_populate <- paste0(mysql_populate, ",Input data")
 mysql_populate_update <- paste0(mysql_populate_update, ",Input data")
 
 ##### Add clinical data if available
-if (runClinicalChunk ) {
+if (runClinicalChunk) {
   mysql_populate <- paste0(mysql_populate, ",Clinical information")
   mysql_populate_update <- paste0(mysql_populate_update, ",Clinical information")
 }
@@ -5022,8 +4931,8 @@ writeLines(mysql_populate, con = paste0(results_dir, "/", sample_name, ".RNAseq_
 <font size="2">
 
 ```{r params_info, comment = NA}
-for ( i in 1:length(params) ) {
-  cat(paste("Parameter: ", names(params)[i], "\nValue: ", paste(unlist(params[i]), collapse = ","), "\n\n", sep=""))
+for (i in 1:length(params)) {
+  cat(paste("Parameter: ", names(params)[i], "\nValue: ", paste(unlist(params[i]), collapse = ","), "\n\n", sep = ""))
 }
 ```
 
@@ -5035,7 +4944,7 @@ for ( i in 1:length(params) ) {
 <font size="2">
 
 ```{r reporter_details, comment = NA}
-cat(paste0("The report was generated by \"", Sys.info()[ "user"], "\" using \"",  Sys.info()[ "nodename"], "\" node and \"",  Sys.info()[ "sysname"], "\" operating system."))
+cat(paste0("The report was generated by \"", Sys.info()["user"], "\" using \"", Sys.info()["nodename"], "\" node and \"", Sys.info()["sysname"], "\" operating system."))
 ```
 
 </font>


### PR DESCRIPTION
Running `styler::tidyverse_style` to enforce a consistent style throughout the Rmd. Takes care of things like trailing whitespace, empty lines, function args without space, indentation etc.
No need to spend time on this one @skanwal, just give the first few lines a skim and you'll get the gist.