### PR TITLE
Use micromamba in GitHub Actions

### DIFF
--- a/.github/workflows/conda_docker_pkgdown.yml
+++ b/.github/workflows/conda_docker_pkgdown.yml
@@ -24,25 +24,16 @@ jobs:
     steps:
       - name: Code checkout
         uses: actions/checkout@v3
-      - name: Miniconda setup
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Micromamba setup
+        uses: mamba-org/setup-micromamba@v1
         with:
-          auto-update-conda: true
-          add-pip-as-python-dependency: false # conda-lock goes crazy if pip pre-installed
-          activate-environment: env1
-          mamba-version: "*"
-          channels: "umccr,conda-forge,bioconda"
+          micromamba-version: '1.4.9-0'
+          environment-file: ${{ env.env_yaml_path }}/condabuild.yaml
       - name: 🐍 Conda pkg build and upload
         run: |
-          conda activate
-          mamba create --name cbuildenv conda-build conda-verify anaconda-client boa
-          conda activate cbuildenv
           conda mambabuild --R 4.2 ${recipe_path} --token ${atoken}
       - name: 🔒 Conda lock
         run: |
-          conda activate
-          mamba create --name lockenv conda-lock pip
-          conda activate lockenv
           conda-lock --file ${env_yaml_path}/rnasum.yaml --platform linux-64
           mv conda-lock.yml ${env_lock_path}/conda-lock.yml
       - name: 💾 Commit lockfile
@@ -57,10 +48,8 @@ jobs:
 
       - name: 🌐 Website publish
         run: |
-          conda activate
-          mamba env create -n pkgdownenv -f ${env_yaml_path}/pkgdown.yaml
-          conda activate pkgdownenv
-
+          micromamba env create -n pkgdownenv -f ${env_yaml_path}/pkgdown.yaml
+          micromamba activate pkgdownenv
           rnasum.R --version
           Rscript -e "pkgdown::deploy_to_branch(pkg = '.', commit_message = paste(pkgdown:::construct_commit_message('.'), '- see https://umccr.github.io/RNAsum/'), branch = 'gh-pages', new_process = FALSE)"
 
@@ -113,10 +102,9 @@ jobs:
           echo "repo_nm: ${REPO_NM}"
           echo "REPO_NM_LC=${REPO_NM,,}" >> ${GITHUB_ENV}
       - name: 🐳 Docker img build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           tags: ghcr.io/${{ env.REPO_NM_LC }}:${{ env.VERSION }}
           context: .
           push: true
           platforms: linux/amd64
-

--- a/deploy/conda/env/yaml/condabuild.yaml
+++ b/deploy/conda/env/yaml/condabuild.yaml
@@ -1,0 +1,10 @@
+name: cbuildenv
+
+channels:
+  - conda-forge
+dependencies:
+  - conda-build
+  - conda-lock
+  - conda-verify
+  - anaconda-client
+  - boa

--- a/deploy/conda/env/yaml/pkgdown.yaml
+++ b/deploy/conda/env/yaml/pkgdown.yaml
@@ -1,5 +1,7 @@
 channels:
-  - local
+  - umccr
+  - conda-forge
+  - bioconda
 dependencies:
   - r-rnasum
   - r-kableextra


### PR DESCRIPTION
Switching from `conda-incubator/setup-miniconda` to `mamba-org/setup-micromamba` which is more actively maintained.