### PR TITLE
Add local download/runner script

### DIFF
--- a/inst/scripts/icav1_download_and_run.R
+++ b/inst/scripts/icav1_download_and_run.R
@@ -1,22 +1,38 @@
 # helpers for downloading GDS data for local testing
 require(dracarys)
-require(tidyverse)
+require(dplyr)
+require(readr)
 require(glue, include.only = "glue")
 require(here, include.only = "here")
-
-glims_read <- function() {
-  lims_key <- googledrive::drive_find("^Google LIMS$", shared_drive = "LIMS")$id
-  lims <- lims_key |>
-    googlesheets4::read_sheet("Sheet1", na = c(".", "", "-"), col_types = "c")
-  lims |> readr::type_convert(col_types = readr::cols(.default = "c", Timestamp = "T"))
-}
-lims_rds <- here::here(glue("nogit/data_portal/lims.rds"))
-# lims_raw <- glims_read()
+date1 <- "2023-10-10"
+lims_rds <- here::here(glue("nogit/data_portal/lims/{date1}.rds"))
+# lims_raw <- dracarys::glims_read()
 # saveRDS(lims_raw, file = lims_rds)
 lims_raw <- readr::read_rds(lims_rds)
-pmeta_rds <- here::here(glue("nogit/data_portal/workflows.rds"))
+
+athena_rnasum <- function(sbj) {
+  RAthena::RAthena_options(clear_s3_resource = FALSE)
+  con <- DBI::dbConnect(
+    RAthena::athena(),
+    work_group = "data_portal",
+    rstudio_conn_tab = FALSE
+  )
+  q_quote <- shQuote(paste(glue("rnasum__{sbj}"), collapse = "|"))
+  q1 <- glue(
+    'SELECT * FROM "data_portal"."data_portal"."data_portal_workflow" where REGEXP_LIKE("wfr_name", {q_quote});'
+  )
+  d <- RAthena::dbGetQuery(con, q1) |>
+    tibble::as_tibble()
+  d |>
+    dracarys::meta_rnasum()
+}
+
+
+
+sbj <- c("SBJ04215", "SBJ04371", "SBJ04378", "SBJ04379")
+pmeta_rds <- here::here(glue("nogit/data_portal/workflows/{date1}.rds"))
 # grab last X RNAsum runs via portal API
-# pmeta_raw <- dracarys::portal_meta_read(params = "&type_name=rnasum", rows = 10)
+# pmeta_raw <- athena_rnasum(sbj)
 # saveRDS(pmeta_raw, file = pmeta_rds)
 pmeta_raw <- readr::read_rds(pmeta_rds)
 
@@ -25,11 +41,9 @@ lims <- lims_raw |>
     Timestamp, SubjectID, SampleID, SampleName, LibraryID, ExternalSubjectID, ExternalSampleID,
     ProjectOwner, ProjectName, Type, Assay, Phenotype, Source, Quality, Topup, Workflow
   )
-pmeta <- pmeta_raw
 
 # generate tidy rnasum metadata from portal workflows table, and join against glims
-meta_rnasum <- pmeta |>
-  dracarys::meta_rnasum(status = c("Succeeded", "Failed")) |>
+pmeta <- pmeta_raw |>
   dplyr::left_join(lims, by = c("LibraryID", "SampleID", "SubjectID")) |>
   dplyr::select(
     gds_indir_dragen, gds_indir_umccrise, gds_indir_arriba,
@@ -38,17 +52,27 @@ meta_rnasum <- pmeta |>
     # ExternalSubjectID, ProjectOwner, ProjectName, Type, Assay, Source, Quality, Workflow,
     wfr_id, start, end, gds_outfile_rnasum_html,
   ) |>
-  dplyr::arrange(desc(SubjectID), start)
+  dplyr::arrange(desc(SubjectID), start) |>
+  # just keep PANCAN to get rid of dups
+  dplyr::filter(rnasum_dataset == "PANCAN")
 
-# melt gds_indir columns to get a single column with paths to gds directories
-# of interest, so that we can fish out files of interest from each of them
-meta_rnasum <- meta_rnasum |>
-  tidyr::pivot_longer(dplyr::contains("gds_indir"), names_to = "folder_type", values_to = "gds_indir") |>
-  dplyr::select(SubjectID, LibraryID, rnasum_dataset, folder_type, gds_indir) |>
-  dplyr::mutate(
-    folder_type = sub("gds_indir_", "", folder_type),
-    local_outdir = here::here(glue::glue("nogit/patient_data/{SubjectID}/{LibraryID}/{rnasum_dataset}/{folder_type}")),
-  )
+# download gds files to a local structure reflecting the gds path starting from
+# the outdir as the fs root.
+rnasum_download <- function(gdsdir, outdir, token, page_size = 200, regexes) {
+  dracarys::gds_files_list(gdsdir = gdsdir, token = token, page_size = page_size) |>
+    dplyr::mutate(type = purrr::map_chr(.data$bname, \(x) dracarys::match_regex(x, regexes))) |>
+    dplyr::select("file_id", "type", "size", "path", "bname") |>
+    dplyr::filter(!is.na(.data$type)) |>
+    dplyr::rowwise() |>
+    dplyr::mutate(
+      dname = dirname(.data$path),
+      dname = sub("gds://", "", .data$dname),
+      local_outdir = fs::dir_create(file.path(outdir, .data$dname)),
+      outfile = file.path(local_outdir, .data$bname),
+      out_dl = gds_file_download_api(.data$file_id, .data$outfile, token)
+    ) |>
+    dplyr::ungroup()
+}
 
 # patterns of files to fish out
 rnasum_file_regex <- tibble::tribble(
@@ -63,22 +87,24 @@ rnasum_file_regex <- tibble::tribble(
   "manta\\.tsv$", "MantaTsvFile",
 )
 token <- dracarys::ica_token_validate()
-dryrun <- F
+outdir <- here::here("nogit/patient_data")
 
-# download files locally
-down <- meta_rnasum |>
+# melt gds_indir columns to get a single column with paths to gds directories
+# of interest, and fish out files of interest from each of them, then download
+meta_rnasum <- pmeta |>
+  tidyr::pivot_longer(dplyr::contains("gds_indir"), names_to = "folder_type", values_to = "gds_indir") |>
+  dplyr::select(SubjectID, LibraryID, rnasum_dataset, folder_type, gds_indir) |>
   dplyr::rowwise() |>
   dplyr::mutate(
-    down = list(dracarys::dr_gds_download(.data$gds_indir, token = token, page_size = 150, outdir = .data$local_outdir, dryrun = dryrun, regexes = rnasum_file_regex))
+    down = list(rnasum_download(gdsdir = gds_indir, outdir = outdir, token = token, regexes = rnasum_file_regex))
   ) |>
   dplyr::ungroup()
 
-# saveRDS(down, here::here("nogit/patient_data/down_2023-08-09.rds"))
-# down <- here::here("nogit/patient_data/down_2023-08-09.rds") |> readr::read_rds()
-
-params_set <- function(arriba_pdf, arriba_tsv, dataset, dragen_fusions, manta_tsv,
-                       pcgr_tiers_tsv, purple_gene_tsv, report_dir, salmon,
-                       sample_name, subject_id) {
+# saveRDS(meta_rnasum, here(glue("nogit/patient_data/down_{date1}.rds")))
+# down <- here::here("nogit/patient_data/down_{date1}.rds") |> readr::read_rds()
+rnasum_params_set <- function(arriba_pdf, arriba_tsv, dataset, dragen_fusions, manta_tsv,
+                              pcgr_tiers_tsv, purple_gene_tsv, report_dir, salmon,
+                              sample_name, subject_id) {
   params <- list(
     arriba_pdf = arriba_pdf,
     arriba_tsv = arriba_tsv,
@@ -114,18 +140,18 @@ params_set <- function(arriba_pdf, arriba_tsv, dataset, dragen_fusions, manta_ts
 }
 
 # now unmelt to have one row per run
-d <- down |>
+d <- meta_rnasum |>
   tidyr::unnest(down) |>
-  dplyr::select(-c("file_id", "dname", "size", "path", "bname", "out_dl", "local_outdir", "gds_indir", "folder_type")) |>
-  tidyr::pivot_wider(names_from = type, values_from = out)
+  dplyr::select(SubjectID, LibraryID, rnasum_dataset, type, outfile) |>
+  tidyr::pivot_wider(names_from = type, values_from = outfile)
 
 # slice to whichever run you want from d
 d |>
-  dplyr::slice(3) |>
+  dplyr::slice(4) |>
   dplyr::rowwise() |>
   dplyr::mutate(
     params = list(
-      params_set(
+      rnasum_params_set(
         arriba_pdf = ArribaFusionsPdfFile, arriba_tsv = ArribaFusionsTsvFile, dataset = rnasum_dataset,
         dragen_fusions = DragenWtsFusionsFinalFile, manta_tsv = MantaTsvFile,
         pcgr_tiers_tsv = PcgrTiersTsvFile, purple_gene_tsv = PurpleCnvGeneTsvFile,
@@ -133,7 +159,7 @@ d |>
         salmon = DragenWtsQuantSfFile, sample_name = glue::glue("{SubjectID}_{LibraryID}"), subject_id = SubjectID
       )
     ),
-    rnasum_rmd = rnasum_rmd(
+    rnasum_rmd = RNAsum::rnasum_rmd(
       out_file = here::here(glue::glue("nogit/patient_data/reports_html/{SubjectID}_{LibraryID}_{rnasum_dataset}.html")),
       quiet = FALSE, pars = params
     )

--- a/inst/scripts/icav1_download_and_run.R
+++ b/inst/scripts/icav1_download_and_run.R
@@ -5,11 +5,13 @@ require(readr)
 require(glue, include.only = "glue")
 require(here, include.only = "here")
 date1 <- "2023-10-10"
+# grab glims
 lims_rds <- here::here(glue("nogit/data_portal/lims/{date1}.rds"))
 # lims_raw <- dracarys::glims_read()
 # saveRDS(lims_raw, file = lims_rds)
 lims_raw <- readr::read_rds(lims_rds)
 
+# grab rnasum workflow metadata from Athena
 athena_rnasum <- function(sbj) {
   RAthena::RAthena_options(clear_s3_resource = FALSE)
   con <- DBI::dbConnect(
@@ -27,11 +29,9 @@ athena_rnasum <- function(sbj) {
     dracarys::meta_rnasum()
 }
 
-
-
+# SBJ IDs of interest
 sbj <- c("SBJ04215", "SBJ04371", "SBJ04378", "SBJ04379")
 pmeta_rds <- here::here(glue("nogit/data_portal/workflows/{date1}.rds"))
-# grab last X RNAsum runs via portal API
 # pmeta_raw <- athena_rnasum(sbj)
 # saveRDS(pmeta_raw, file = pmeta_rds)
 pmeta_raw <- readr::read_rds(pmeta_rds)
@@ -101,7 +101,7 @@ meta_rnasum <- pmeta |>
   dplyr::ungroup()
 
 # saveRDS(meta_rnasum, here(glue("nogit/patient_data/down_{date1}.rds")))
-# down <- here::here("nogit/patient_data/down_{date1}.rds") |> readr::read_rds()
+# meta_rnasum <- here::here(glue("nogit/patient_data/down_{date1}.rds")) |> readr::read_rds()
 rnasum_params_set <- function(arriba_pdf, arriba_tsv, dataset, dragen_fusions, manta_tsv,
                               pcgr_tiers_tsv, purple_gene_tsv, report_dir, salmon,
                               sample_name, subject_id) {
@@ -159,9 +159,9 @@ d |>
         salmon = DragenWtsQuantSfFile, sample_name = glue::glue("{SubjectID}_{LibraryID}"), subject_id = SubjectID
       )
     ),
-    rnasum_rmd = RNAsum::rnasum_rmd(
-      out_file = here::here(glue::glue("nogit/patient_data/reports_html/{SubjectID}_{LibraryID}_{rnasum_dataset}.html")),
-      quiet = FALSE, pars = params
-    )
+    # rnasum_rmd = RNAsum::rnasum_rmd(
+    #   out_file = here::here(glue::glue("nogit/patient_data/reports_html/{SubjectID}_{LibraryID}_{rnasum_dataset}.html")),
+    #   quiet = FALSE, pars = params
+    # )
   ) |>
   dplyr::ungroup()

--- a/inst/scripts/icav1_download_and_run.R
+++ b/inst/scripts/icav1_download_and_run.R
@@ -1,0 +1,141 @@
+# helpers for downloading GDS data for local testing
+require(dracarys)
+require(tidyverse)
+require(glue, include.only = "glue")
+require(here, include.only = "here")
+
+glims_read <- function() {
+  lims_key <- googledrive::drive_find("^Google LIMS$", shared_drive = "LIMS")$id
+  lims <- lims_key |>
+    googlesheets4::read_sheet("Sheet1", na = c(".", "", "-"), col_types = "c")
+  lims |> readr::type_convert(col_types = readr::cols(.default = "c", Timestamp = "T"))
+}
+lims_rds <- here::here(glue("nogit/data_portal/lims.rds"))
+# lims_raw <- glims_read()
+# saveRDS(lims_raw, file = lims_rds)
+lims_raw <- readr::read_rds(lims_rds)
+pmeta_rds <- here::here(glue("nogit/data_portal/workflows.rds"))
+# grab last X RNAsum runs via portal API
+# pmeta_raw <- dracarys::portal_meta_read(params = "&type_name=rnasum", rows = 10)
+# saveRDS(pmeta_raw, file = pmeta_rds)
+pmeta_raw <- readr::read_rds(pmeta_rds)
+
+lims <- lims_raw |>
+  dplyr::select(
+    Timestamp, SubjectID, SampleID, SampleName, LibraryID, ExternalSubjectID, ExternalSampleID,
+    ProjectOwner, ProjectName, Type, Assay, Phenotype, Source, Quality, Topup, Workflow
+  )
+pmeta <- pmeta_raw
+
+# generate tidy rnasum metadata from portal workflows table, and join against glims
+meta_rnasum <- pmeta |>
+  dracarys::meta_rnasum(status = c("Succeeded", "Failed")) |>
+  dplyr::left_join(lims, by = c("LibraryID", "SampleID", "SubjectID")) |>
+  dplyr::select(
+    gds_indir_dragen, gds_indir_umccrise, gds_indir_arriba,
+    SubjectID, LibraryID, SampleID, Phenotype, rnasum_dataset,
+    end_status,
+    # ExternalSubjectID, ProjectOwner, ProjectName, Type, Assay, Source, Quality, Workflow,
+    wfr_id, start, end, gds_outfile_rnasum_html,
+  ) |>
+  dplyr::arrange(desc(SubjectID), start)
+
+# melt gds_indir columns to get a single column with paths to gds directories
+# of interest, so that we can fish out files of interest from each of them
+meta_rnasum <- meta_rnasum |>
+  tidyr::pivot_longer(dplyr::contains("gds_indir"), names_to = "folder_type", values_to = "gds_indir") |>
+  dplyr::select(SubjectID, LibraryID, rnasum_dataset, folder_type, gds_indir) |>
+  dplyr::mutate(
+    folder_type = sub("gds_indir_", "", folder_type),
+    local_outdir = here::here(glue::glue("nogit/patient_data/{SubjectID}/{LibraryID}/{rnasum_dataset}/{folder_type}")),
+  )
+
+# patterns of files to fish out
+rnasum_file_regex <- tibble::tribble(
+  ~regex, ~fun,
+  "quant\\.genes\\.sf$", "DragenWtsQuantGenesSfFile",
+  "quant\\.sf$", "DragenWtsQuantSfFile",
+  "fusion_candidates\\.final$", "DragenWtsFusionsFinalFile",
+  "fusions\\.pdf$", "ArribaFusionsPdfFile",
+  "fusions\\.tsv$", "ArribaFusionsTsvFile",
+  "somatic\\.pcgr\\.snvs_indels\\.tiers\\.tsv$", "PcgrTiersTsvFile",
+  "purple\\.cnv\\.gene\\.tsv$", "PurpleCnvGeneTsvFile",
+  "manta\\.tsv$", "MantaTsvFile",
+)
+token <- dracarys::ica_token_validate()
+dryrun <- F
+
+# download files locally
+down <- meta_rnasum |>
+  dplyr::rowwise() |>
+  dplyr::mutate(
+    down = list(dracarys::dr_gds_download(.data$gds_indir, token = token, page_size = 150, outdir = .data$local_outdir, dryrun = dryrun, regexes = rnasum_file_regex))
+  ) |>
+  dplyr::ungroup()
+
+# saveRDS(down, here::here("nogit/patient_data/down_2023-08-09.rds"))
+# down <- here::here("nogit/patient_data/down_2023-08-09.rds") |> readr::read_rds()
+
+params_set <- function(arriba_pdf, arriba_tsv, dataset, dragen_fusions, manta_tsv,
+                       pcgr_tiers_tsv, purple_gene_tsv, report_dir, salmon,
+                       sample_name, subject_id) {
+  params <- list(
+    arriba_pdf = arriba_pdf,
+    arriba_tsv = arriba_tsv,
+    batch_rm = TRUE,
+    cn_gain = 95,
+    cn_loss = 5,
+    dataset = dataset,
+    dataset_name_incl = TRUE,
+    dragen_fusions = dragen_fusions,
+    drugs = FALSE,
+    filter = TRUE,
+    immunogram = FALSE,
+    log = TRUE,
+    manta_tsv = manta_tsv,
+    norm = "TMM",
+    pcgr_splice_vars = TRUE,
+    pcgr_tier = 4,
+    pcgr_tiers_tsv = pcgr_tiers_tsv,
+    project = "-",
+    purple_gene_tsv = purple_gene_tsv,
+    report_dir = report_dir,
+    salmon = salmon,
+    sample_name = sample_name,
+    sample_source = "-",
+    save_tables = TRUE,
+    scaling = "gene-wise",
+    subject_id = subject_id,
+    top_genes = 5,
+    transform = "CPM",
+    umccrise = NULL
+  )
+  params
+}
+
+# now unmelt to have one row per run
+d <- down |>
+  tidyr::unnest(down) |>
+  dplyr::select(-c("file_id", "dname", "size", "path", "bname", "out_dl", "local_outdir", "gds_indir", "folder_type")) |>
+  tidyr::pivot_wider(names_from = type, values_from = out)
+
+# slice to whichever run you want from d
+d |>
+  dplyr::slice(3) |>
+  dplyr::rowwise() |>
+  dplyr::mutate(
+    params = list(
+      params_set(
+        arriba_pdf = ArribaFusionsPdfFile, arriba_tsv = ArribaFusionsTsvFile, dataset = rnasum_dataset,
+        dragen_fusions = DragenWtsFusionsFinalFile, manta_tsv = MantaTsvFile,
+        pcgr_tiers_tsv = PcgrTiersTsvFile, purple_gene_tsv = PurpleCnvGeneTsvFile,
+        report_dir = here::here(glue::glue("nogit/patient_data/reports/{SubjectID}_{LibraryID}_{rnasum_dataset}")),
+        salmon = DragenWtsQuantSfFile, sample_name = glue::glue("{SubjectID}_{LibraryID}"), subject_id = SubjectID
+      )
+    ),
+    rnasum_rmd = rnasum_rmd(
+      out_file = here::here(glue::glue("nogit/patient_data/reports_html/{SubjectID}_{LibraryID}_{rnasum_dataset}.html")),
+      quiet = FALSE, pars = params
+    )
+  ) |>
+  dplyr::ungroup()

--- a/inst/scripts/icav1_download_and_run.R
+++ b/inst/scripts/icav1_download_and_run.R
@@ -69,7 +69,7 @@ rnasum_download <- function(gdsdir, outdir, token, page_size = 200, regexes) {
       dname = sub("gds://", "", .data$dname),
       local_outdir = fs::dir_create(file.path(outdir, .data$dname)),
       outfile = file.path(local_outdir, .data$bname),
-      out_dl = gds_file_download_api(.data$file_id, .data$outfile, token)
+      out_dl = dracarys::gds_file_download_api(.data$file_id, .data$outfile, token)
     ) |>
     dplyr::ungroup()
 }


### PR DESCRIPTION
This script can be used to (interactively) download the required umccrise/DragenWTS/arriba inputs from GDS for local testing/debugging, and to further render the RMarkdown report. Basic steps are:

- Specify SBJ IDs of interest
- Filter the Athena `data_portal_workflow` table for RNAsum workflows run on those SBJs (using [{RAthena}](https://github.com/DyfanJones/RAthena))
- Grab the required metadata from the above table, such as `gds_indir_dragen`, `gds_indir_umccrise`, `gds_indir_arriba`, which point to GDS locations of the aforementioned inputs.
- Now in each of those GDS directories, search for files matching a certain pattern, and download locally to a file structure matching GDS but from a localy root you specify (`/path/to/rnasum/nogit/patient_data` for me below).
- Then since you have all the paths to the downloaded files, you can submit those to the `RNAsum::rnasum_rmd` function to render the RMarkdown report.