### PR TITLE
Rmd refactor (part 10)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,6 +57,7 @@ Imports:
     scales,
     sessioninfo,
     stats,
+    stringr,
     tibble,
     tidyr,
     tximport

--- a/R/fusions.R
+++ b/R/fusions.R
@@ -161,6 +161,11 @@ fusions_table <- function(fusions) {
       )
     ) |>
     dplyr::ungroup() |>
+    # use desc since values are True (1) / False (0), so go from high (1) to low (0)
+    dplyr::arrange(
+      dplyr::desc(.data$geneA_dna_support), dplyr::desc(.data$geneB_dna_support),
+      dplyr::desc(.data$reported_fusion), .data$fusion_caller
+    ) |>
     dplyr::select(dplyr::any_of(
       # any_of handles cases when Arriba fusions are missing so e.g. there is no split_readsA col
       c(

--- a/R/perc_rank.R
+++ b/R/perc_rank.R
@@ -7,5 +7,5 @@
 #' @return Vector of percentiles
 #' @export
 perc_rank <- function(x) {
-  base::trunc(base::rank(x))*100/base::length(x)
+  base::trunc(base::rank(x)) * 100 / base::length(x)
 }

--- a/R/salmon.R
+++ b/R/salmon.R
@@ -29,7 +29,7 @@ salmon_counts <- function(x, tx2gene = NULL) {
   if (grepl("genes.sf", basename(x), fixed = TRUE)) {
     counts <- readr::read_tsv(x, col_types = readr::cols(.default = "c", NumReads = "d")) |>
       dplyr::select("Name", "NumReads") |>
-      dplyr::rename(rowname = Name, count = NumReads) |>
+      dplyr::rename(rowname = "Name", count = "NumReads") |>
       dplyr::filter(!grepl("PAR_Y", .data$rowname))
   } else {
     txi_salmon <- tximport::tximport(files = x, type = "salmon", tx2gene = tx2gene)
@@ -38,6 +38,6 @@ salmon_counts <- function(x, tx2gene = NULL) {
       dplyr::rename(count = .data$X)
   }
   counts <- counts |>
-    dplyr::mutate(rowname = sub("\\..*", "", rowname))
+    dplyr::mutate(rowname = sub("\\..*", "", .data$rowname))
   return(counts)
 }

--- a/R/sample_data.R
+++ b/R/sample_data.R
@@ -34,7 +34,7 @@
 #' )
 #' res <- read_sample_data(p, tempdir())
 #' @testexamples
-#' expect_equal(length(res), 5)
+#' expect_equal(length(res), 6)
 #' expect_null(res$salmon)
 #' @export
 read_sample_data <- function(p, results_dir, tx2gene = NULL) {

--- a/R/sample_data.R
+++ b/R/sample_data.R
@@ -38,9 +38,16 @@
 #' expect_null(res$salmon)
 #' @export
 read_sample_data <- function(p, results_dir, tx2gene = NULL) {
-  arriba_tsv <- arriba_tsv_read(p[["arriba_tsv"]])
-  arriba_pdf <- p[["arriba_pdf"]] |>
-    arriba_pdf_read(fusions = arriba_tsv, outdir = file.path(results_dir, "arriba"))
+  # if only arriba_dir is provided, construct the paths to pdf and tsv
+  arriba_tsv <- p[["arriba_tsv"]]
+  arriba_pdf <- p[["arriba_pdf"]]
+  arriba_dir <- p[["arriba_dir"]]
+  if (is.null(arriba_tsv) && is.null(arriba_pdf) && !is.null(arriba_dir)) {
+    arriba_tsv <- file.path(arriba_dir, "fusions.tsv")
+    arriba_pdf <- file.path(arriba_dir, "fusions.pdf")
+  }
+  arriba_tsv <- arriba_tsv_read(x = arriba_tsv)
+  arriba_pdf <- arriba_pdf_read(pdf = arriba_pdf, fusions = arriba_tsv, outdir = file.path(results_dir, "arriba"))
   salmon <- salmon_counts(p[["salmon"]], tx2gene = tx2gene)
   dragen_fusions <- dragen_fusions_read(p[["dragen_fusions"]])
   dragen_mapping_metrics <- dragen_mapping_metrics_read(p[["dragen_mapping_metrics"]])

--- a/R/sample_data.R
+++ b/R/sample_data.R
@@ -1,7 +1,7 @@
 #' Read Sample Data
 #'
 #' Reads sample data, including Arriba fusions, Arriba plots, Salmon counts,
-#' and DRAGEN fusions.
+#' DRAGEN fusions, DRAGEN mapping metrics, Manta SVs, PURPLE CNVs, and PCGR SNVs.
 #'
 #' @param p RNAsum params list.
 #' @param results_dir Directory to output extracted Arriba PNGs to (created
@@ -12,45 +12,57 @@
 #' @return A list of the input sample data.
 #' @examples
 #' p <- list(
-#'   dragen_rnaseq = system.file("rawdata/test_data/dragen", package = "RNAsum"),
-#'   arriba_pdf = system.file("rawdata/test_data/dragen/arriba/fusions.pdf", package = "RNAsum"),
-#'   arriba_tsv = system.file("rawdata/test_data/dragen/arriba/fusions.tsv", package = "RNAsum"),
-#'   dragen_fusions = system.file(
-#'     "rawdata/test_data/dragen/test_sample_WTS.fusion_candidates.final",
-#'     package = "RNAsum"
-#'   ),
-#'   dragen_mapping_metrics = system.file(
-#'     "rawdata/test_data/dragen/test.mapping_metrics.csv",
-#'     package = "RNAsum"
-#'   ),
+#'   dragen_wts_dir = system.file("rawdata/test_data/dragen", package = "RNAsum"),
+#'   arriba_dir = system.file("rawdata/test_data/dragen/arriba", package = "RNAsum"),
 #'   umccrise = system.file(
 #'     "rawdata/test_data/umccrised/test_sample_WGS",
-#'     package = "RNAsum"
-#'   ),
-#'   manta_tsv = system.file(
-#'     "rawdata/test_data/umccrised/test_sample_WGS/structural/manta.tsv",
 #'     package = "RNAsum"
 #'   )
 #' )
 #' res <- read_sample_data(p, tempdir())
 #' @testexamples
 #' expect_equal(length(res), 6)
-#' expect_null(res$salmon)
+#' expect_null(res$salmon) # because tx2gene in NULL
 #' @export
 read_sample_data <- function(p, results_dir, tx2gene = NULL) {
-  # if only arriba_dir is provided, construct the paths to pdf and tsv
+  #---- Arriba ----#
+  # if any of arriba tsv/pdf missing and arriba_dir is provided,
+  # construct the paths to files from that.
   arriba_tsv <- p[["arriba_tsv"]]
   arriba_pdf <- p[["arriba_pdf"]]
   arriba_dir <- p[["arriba_dir"]]
-  if (is.null(arriba_tsv) && is.null(arriba_pdf) && !is.null(arriba_dir)) {
+  if (!is.null(arriba_dir) && (list(NULL) %in% list(arriba_tsv, arriba_pdf))) {
     arriba_tsv <- file.path(arriba_dir, "fusions.tsv")
     arriba_pdf <- file.path(arriba_dir, "fusions.pdf")
   }
   arriba_tsv <- arriba_tsv_read(x = arriba_tsv)
   arriba_pdf <- arriba_pdf_read(pdf = arriba_pdf, fusions = arriba_tsv, outdir = file.path(results_dir, "arriba"))
-  salmon <- salmon_counts(p[["salmon"]], tx2gene = tx2gene)
-  dragen_fusions <- dragen_fusions_read(p[["dragen_fusions"]])
-  dragen_mapping_metrics <- dragen_mapping_metrics_read(p[["dragen_mapping_metrics"]])
+
+  #---- DragenWTS ----#
+  # if any of salmon, fusions, mapmetrics missing and dragen_wts_dir is provided,
+  # construct the paths to files from that.
+  salmon <- p[["salmon"]]
+  dragen_fusions <- p[["dragen_fusions"]]
+  dragen_mapping_metrics <- p[["dragen_mapping_metrics"]]
+  dragen_wts_dir <- p[["dragen_wts_dir"]]
+  if (!is.null(dragen_wts_dir) && (list(NULL) %in% list(salmon, dragen_fusions, dragen_mapping_metrics))) {
+    salmon <- list.files(dragen_wts_dir, pattern = "quant\\.genes\\.sf", full.names = TRUE)
+    dragen_mapping_metrics <- list.files(dragen_wts_dir, pattern = "mapping_metrics\\.csv", full.names = TRUE)
+    dragen_fusions <- list.files(dragen_wts_dir, pattern = "fusion_candidates\\.final", full.names = TRUE)
+    if (length(salmon) != 1) {
+      salmon <- NULL
+    }
+    if (length(dragen_mapping_metrics) != 1) {
+      dragen_mapping_metrics <- NULL
+    }
+    if (length(dragen_fusions) != 1) {
+      dragen_fusions <- NULL
+    }
+  }
+  salmon <- salmon_counts(salmon, tx2gene = tx2gene)
+  dragen_fusions <- dragen_fusions_read(dragen_fusions)
+  dragen_mapping_metrics <- dragen_mapping_metrics_read(dragen_mapping_metrics)
+  #---- WGS ----#
   wgs <- read_wgs_data(p)
   list(
     arriba_tsv = arriba_tsv,

--- a/R/sv.R
+++ b/R/sv.R
@@ -39,7 +39,7 @@ manta_process <- function(manta_tsv_obj) {
 }
 
 sv_prioritize_old <- function(sv_file) {
-  # grab the dplyr pipe
+  # grab the dplyr pipe (for now!)
   `%>%` <- dplyr::`%>%`
   subset_genes <- function(genes, ind) {
     genes |>
@@ -82,7 +82,35 @@ sv_prioritize_old <- function(sv_file) {
   if (length(readLines(con = sv_file, n = 2)) <= 1) {
     return(sv_all)
   }
-  sv_all <- readr::read_tsv(sv_file, col_names = TRUE) |>
+
+  col_types_tab <- dplyr::tribble(
+    ~Column, ~Description, ~Type,
+    "caller", "Manta SV caller", "c",
+    "sample", "Tumor sample name", "c",
+    "chrom", "CHROM column in VCF", "c",
+    "start", "POS column in VCF", "i",
+    "end", "INFO/END: End position of the variant described in this record", "i",
+    "svtype", "INFO/SVTYPE: Type of structural variant", "c",
+    "split_read_support", "FORMAT/SR of tumor sample: Split reads for the ref and alt alleles in the order listed, for reads where P(allele|read)>0.999", "c",
+    "paired_support_PE", "FORMAT/PE of tumor sample: ??", "c",
+    "paired_support_PR", "FORMAT/PR of tumor sample: Spanning paired-read support for the ref and alt alleles in the order listed, for reads where P(allele|read)>0.999", "c",
+    "AF_BPI", "INFO/BPI_AF: AF at each breakpoint (so AF_BPI1,AF_BPI2)", "c",
+    "somaticscore", "INFO/SOMATICSCORE: Somatic variant quality score", "i",
+    "tier", "INFO/SV_TOP_TIER (or 4 if missing): Highest priority tier for the effects of a variant entry", "c",
+    "annotation", "INFO/SIMPLE_ANN: Simplified structural variant annotation: 'SVTYPE | EFFECT | GENE(s) | TRANSCRIPT | PRIORITY (1-4)'", "c",
+    "AF_PURPLE", "INFO/PURPLE_AF: AF at each breakend (purity adjusted) (so AF_PURPLE1,AF_PURPLE2)", "c",
+    "CN_PURPLE", "INFO/PURPLE_CN: CN at each breakend (purity adjusted) (so CN_PURPLE1,CN_PURPLE2)", "c",
+    "CN_change_PURPLE", "INFO/PURPLE_CN_CHANGE: change in CN at each breakend (purity adjusted) (so CN_change_PURPLE1,CN_change_PURPLE2)", "c",
+    "Ploidy_PURPLE", "INFO/PURPLE_PLOIDY: Ploidy of variant (purity adjusted)", "d",
+    "PURPLE_status", "INFERRED if FILTER=INFERRED, or RECOVERED if has INFO/RECOVERED, else blank. INFERRED: Breakend inferred from copy number transition", "c",
+    "START_BPI", "INFO/BPI_START: BPI adjusted breakend location", "i",
+    "END_BPI", "INFO/BPI_END: BPI adjusted breakend location", "i",
+    "ID", "ID column in VCF", "c",
+    "MATEID", "INFO/MATEID: ID of mate breakend", "c",
+    "ALT", "ALT column in VCF", "c"
+  )
+  ctypes <- paste(col_types_tab$Type, collapse = "")
+  sv_all <- readr::read_tsv(sv_file, col_names = TRUE, col_types = ctypes) |>
     dplyr::select(-c("caller", "sample")) |>
     split_sv_field(AF_BPI, is_pct = T) |>
     split_sv_field(AF_PURPLE, is_pct = T) |>
@@ -101,37 +129,52 @@ sv_prioritize_old <- function(sv_file) {
     dplyr::filter(svtype != "BND" | is.na(SR) | PR > SR) # remove BND with split read support higher than paired
   total_variants <- nrow(sv_all)
   sv_all <- sv_all |>
-    tidyr::unnest(annotation = strsplit(annotation, ",")) |> # Unpack multiple annotations per region
-    tidyr::separate(annotation,
-      c("Event", "Effect", "Genes", "Transcript", "Detail", "Tier"),
-      sep = "\\|", convert = TRUE, fill = "right"
-    ) %>% # Unpack annotation columns
+    # Unpack multiple annotations per region
+    dplyr::mutate(annotation = strsplit(.data$annotation, ",")) |>
+    tidyr::unnest("annotation") |>
+    tidyr::separate_wider_delim(
+      cols = "annotation", delim = "|",
+      names = c("Event", "Effect", "Genes", "Transcript", "Detail", "Tier"), too_few = "align_start"
+    ) |>
     dplyr::mutate(
       start = format(start, big.mark = ",", trim = T),
-      end = format(end, big.mark = ",", trim = T)
-    ) %>%
-    dplyr::mutate(
+      end = format(end, big.mark = ",", trim = T),
       location = stringr::str_c(chrom, ":", start, sep = ""),
       location = ifelse(is.na(end), location, stringr::str_c(location))
-    ) %>%
-    dplyr::arrange(Tier, Effect, desc(AF_PURPLE), Genes) %>%
+    ) |>
     dplyr::mutate(
       Gene = subset_genes(Genes, c(1, 2)),
-      Gene = ifelse((stringr::str_split(Genes, "&") %>% purrr::map_int(length)) > 2,
+      Gene = ifelse((stringr::str_split(Genes, "&") |> purrr::map_int(length)) > 2,
         stringr::str_c(Gene, "...", sep = ", "),
         Gene
       ),
-      `Other affected genes` = subset_genes(Genes, -c(1, 2)) %>% stringr::str_replace_all("&", ", "),
+      `Other affected genes` = subset_genes(Genes, -c(1, 2)) |> stringr::str_replace_all("&", ", "),
       Gene = ifelse(stringr::str_detect(Effect, "gene_fusion"),
         Gene,
-        Gene %>% stringr::str_replace_all("&", ", ")
+        Gene |> stringr::str_replace_all("&", ", ")
       )
-    ) %>%
-    tidyr::separate(Effect, c("Effect", "Other effects"), sep = "&", fill = "right", extra = "merge") %>%
-    dplyr::select(Tier = tier, Event = svtype, Genes = Gene, Effect = Effect, Detail = Detail, Location = location, AF = AF_PURPLE, `CN chg` = CN_change_PURPLE, SR, PR, CN = CN_PURPLE, Ploidy = Ploidy_PURPLE, PURPLE_status, `SR (ref)`, `PR (ref)`, PE, `PE (ref)`, `Somatic score` = somaticscore, Transcript = Transcript, `Other effects`, `Other affected genes`, `AF at breakpoint 1` = AF_PURPLE1, `AF at breakpoint 2` = AF_PURPLE2, `CN at breakpoint 1` = CN_PURPLE1, `CN at breakpoint 2` = CN_PURPLE2, `CN change at breakpoint 1` = CN_change_PURPLE1, `CN change at breakpoint 2` = CN_change_PURPLE2, `AF before adjustment, bp 1` = AF_BPI1, `AF before adjustment, bp 2` = AF_BPI2) %>%
-    dplyr::distinct() |>
+    ) |>
+    tidyr::separate_wider_delim(
+      cols = "Effect", delim = "&", names = c("Effect", "Other effects"),
+      too_few = "align_start", too_many = "merge"
+    ) |>
+    dplyr::select(
+      Tier = "tier", Event = "svtype", Genes = "Gene", Effect = "Effect",
+      Detail = "Detail", Location = "location", AF = "AF_PURPLE", `CN chg` = "CN_change_PURPLE",
+      "SR", "PR", CN = "CN_PURPLE", Ploidy = "Ploidy_PURPLE", "PURPLE_status",
+      "SR (ref)", "PR (ref)", "PE", "PE (ref)", `Somatic score` = "somaticscore",
+      "Transcript", "Other effects", "Other affected genes",
+      `AF at breakpoint 1` = "AF_PURPLE1", `AF at breakpoint 2` = "AF_PURPLE2",
+      `CN at breakpoint 1` = "CN_PURPLE1", `CN at breakpoint 2` = "CN_PURPLE2",
+      `CN change at breakpoint 1` = "CN_change_PURPLE1",
+      `CN change at breakpoint 2` = "CN_change_PURPLE2",
+      `AF before adjustment, bp 1` = "AF_BPI1",
+      `AF before adjustment, bp 2` = "AF_BPI2"
+    ) |>
     # filter out empty gene rows
-    dplyr::filter(Genes != "")
+    dplyr::filter(Genes != "") |>
+    dplyr::distinct() |>
+    dplyr::arrange(.data$Tier, .data$Effect, dplyr::desc(.data$AF), .data$Genes)
   total_melted <- nrow(sv_all)
   return(list(
     melted = sv_all,

--- a/R/sv.R
+++ b/R/sv.R
@@ -125,8 +125,7 @@ sv_prioritize_old <- function(sv_file) {
     tidyr::separate_wider_delim(cols = "paired_support_PE", names = c("PE (ref)", "PE (alt)"), delim = ",", too_few = "align_start") |>
     dplyr::mutate(
       SR = as.integer(.data$`SR (alt)`), PR = as.integer(.data$`PR (alt)`), PE = as.integer(.data$`PE (alt)`)
-    ) |>
-    dplyr::filter(.data$svtype != "BND" | is.na(.data$SR) | .data$PR > .data$SR) # remove BND with split read support higher than paired
+    )
   total_variants <- nrow(sv_all)
   sv_all <- sv_all |>
     # Unpack multiple annotations per region

--- a/deploy/conda/recipe/meta.yaml
+++ b/deploy/conda/recipe/meta.yaml
@@ -51,6 +51,7 @@ requirements:
     - r-rnasum.data
     - r-scales
     - r-sessioninfo
+    - r-stringr
     - r-tibble
     - r-tidyr
     - bioconductor-tximport
@@ -90,6 +91,7 @@ requirements:
     - r-rnasum.data
     - r-scales
     - r-sessioninfo
+    - r-stringr
     - r-tibble
     - r-tidyr
     - bioconductor-tximport

--- a/deploy/conda/recipe/meta.yaml
+++ b/deploy/conda/recipe/meta.yaml
@@ -16,27 +16,28 @@ requirements:
   build:
     - git
   host:
-    - r-base
+    - r-base ==4.1.3
     - bioconductor-annotationdbi
     - bioconductor-annotationfilter
     - r-assertthat
     - r-conflicted
-    - r-dt
+    - r-dt ==0.21
     - r-dplyr
-    - bioconductor-edaseq
+    - bioconductor-edaseq ==2.28.0
     - bioconductor-ensdb.hsapiens.v86
-    - bioconductor-edger
+    - bioconductor-edger ==3.36.0
     - bioconductor-ensembldb
     - r-fs
-    - r-ggplot2
+    - r-ggforce
+    - r-ggplot2 ==3.3.6
     - r-glue
     - r-gpgr
     - r-htmltools
     - r-htmlwidgets
     - r-knitr
-    - bioconductor-limma
-    - r-manhattanly
-    - r-matrixstats
+    - bioconductor-limma ==3.50.1
+    #- r-manhattanly # only for R4.2+
+    - r-matrixstats ==0.61.0
     - r-optparse
     - r-pdftools
     - r-png
@@ -47,34 +48,35 @@ requirements:
     - r-readr
     - r-rlang
     - r-rmarkdown
-    - r-rnasum.data
+    #- r-rnasum.data # only for R4.2+
     - r-scales
     - r-sessioninfo
     - r-tibble
     - r-tidyr
     - bioconductor-tximport
   run:
-    - r-base
+    - r-base ==4.1.3
     - bioconductor-annotationdbi
     - bioconductor-annotationfilter
     - r-assertthat
     - r-conflicted
-    - r-dt
+    - r-dt ==0.21
     - r-dplyr
-    - bioconductor-edaseq
+    - bioconductor-edaseq ==2.28.0
     - bioconductor-ensdb.hsapiens.v86
-    - bioconductor-edger
+    - bioconductor-edger ==3.36.0
     - bioconductor-ensembldb
     - r-fs
-    - r-ggplot2
+    - r-ggforce
+    - r-ggplot2 ==3.3.6
     - r-glue
     - r-gpgr
     - r-htmltools
     - r-htmlwidgets
     - r-knitr
-    - bioconductor-limma
-    - r-manhattanly
-    - r-matrixstats
+    - bioconductor-limma ==3.50.1
+    #- r-manhattanly # only for R4.2+
+    - r-matrixstats ==0.61.0
     - r-optparse
     - r-pdftools
     - r-png
@@ -85,7 +87,7 @@ requirements:
     - r-readr
     - r-rlang
     - r-rmarkdown
-    - r-rnasum.data
+    #- r-rnasum.data # only for R4.2+
     - r-scales
     - r-sessioninfo
     - r-tibble

--- a/deploy/conda/recipe/meta.yaml
+++ b/deploy/conda/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - bioconductor-annotationfilter
     - r-assertthat
     - r-conflicted
-    - r-dt ==0.21
+    - r-dt
     - r-dplyr
     - bioconductor-edaseq ==2.28.0
     - bioconductor-ensdb.hsapiens.v86
@@ -29,14 +29,14 @@ requirements:
     - bioconductor-ensembldb
     - r-fs
     - r-ggforce
-    - r-ggplot2 ==3.3.6
+    - r-ggplot2
     - r-glue
     - r-gpgr
     - r-htmltools
     - r-htmlwidgets
     - r-knitr
     - bioconductor-limma ==3.50.1
-    #- r-manhattanly # only for R4.2+
+    - r-manhattanly # grab for R v4.1 from umccr
     - r-matrixstats ==0.61.0
     - r-optparse
     - r-pdftools
@@ -48,7 +48,7 @@ requirements:
     - r-readr
     - r-rlang
     - r-rmarkdown
-    #- r-rnasum.data # only for R4.2+
+    - r-rnasum.data
     - r-scales
     - r-sessioninfo
     - r-tibble
@@ -60,7 +60,7 @@ requirements:
     - bioconductor-annotationfilter
     - r-assertthat
     - r-conflicted
-    - r-dt ==0.21
+    - r-dt
     - r-dplyr
     - bioconductor-edaseq ==2.28.0
     - bioconductor-ensdb.hsapiens.v86
@@ -68,14 +68,14 @@ requirements:
     - bioconductor-ensembldb
     - r-fs
     - r-ggforce
-    - r-ggplot2 ==3.3.6
+    - r-ggplot2
     - r-glue
     - r-gpgr
     - r-htmltools
     - r-htmlwidgets
     - r-knitr
     - bioconductor-limma ==3.50.1
-    #- r-manhattanly # only for R4.2+
+    - r-manhattanly # grab for R v4.1 from umccr
     - r-matrixstats ==0.61.0
     - r-optparse
     - r-pdftools
@@ -87,7 +87,7 @@ requirements:
     - r-readr
     - r-rlang
     - r-rmarkdown
-    #- r-rnasum.data # only for R4.2+
+    - r-rnasum.data
     - r-scales
     - r-sessioninfo
     - r-tibble

--- a/inst/cli/rnasum.R
+++ b/inst/cli/rnasum.R
@@ -23,6 +23,7 @@ option_list <- list(
   make_option("--dataset_name_incl", action = "store_true", help = "Include dataset in report name."),
   make_option("--dragen_fusions", type = "character", help = "File path to DRAGEN RNA-seq 'fusion_candidates.final' output."),
   make_option("--dragen_mapping_metrics", type = "character", help = "File path to DRAGEN RNA-seq 'mapping_metrics.csv' output."),
+  make_option("--dragen_wts_dir", type = "character", help = "Directory path to DRAGEN RNA-seq results."),
   make_option("--drugs", action = "store_true", help = "Include drug matching section in report."),
   make_option("--filter", action = "store_true", help = "Filter out low expressed genes."),
   make_option("--immunogram", action = "store_true", help = "Include immunogram in report."),

--- a/inst/cli/rnasum.R
+++ b/inst/cli/rnasum.R
@@ -15,42 +15,42 @@ suppressMessages(library(fs, include.only = "dir_create"))
 option_list <- list(
   make_option("--arriba_pdf", type = "character", help = "File path of Arriba PDF output."),
   make_option("--arriba_tsv", type = "character", help = "File path of Arriba TSV output."),
-  make_option("--batch_rm", action = "store_false", default = TRUE, help = "Remove batch-associated effects between datasets? [def: %default]"),
+  make_option("--batch_rm", action = "store_true", help = "Remove batch-associated effects between datasets."),
   make_option("--cn_gain", default = 95, type = "integer", help = "CN threshold value to classify genes within gained regions. [def: %default]"),
   make_option("--cn_loss", default = 5, type = "integer", help = "CN threshold value to classify genes within lost regions. [def: %default]"),
   make_option("--dataset", default = "PANCAN", type = "character", help = "Dataset to be used as external reference cohort. [def: %default]"),
-  make_option("--dataset_name_incl", action = "store_true", default = FALSE, help = "Include dataset in report name? [def: %default]"),
+  make_option("--dataset_name_incl", action = "store_true", help = "Include dataset in report name."),
   make_option("--dragen_fusions", type = "character", help = "File path to DRAGEN RNA-seq 'fusion_candidates.final' output."),
   make_option("--dragen_mapping_metrics", type = "character", help = "File path to DRAGEN RNA-seq 'mapping_metrics.csv' output."),
-  make_option("--drugs", action = "store_true", default = FALSE, help = "Include drug matching section in report? [def: %default]"),
-  make_option("--filter", action = "store_false", default = TRUE, help = "Filter out low expressed genes? [def: %default]"),
-  make_option("--immunogram", action = "store_true", default = FALSE, help = "Include immunogram in report? [def: %default]"),
-  make_option("--log", action = "store_false", default = TRUE, help = "Log2 transform data before normalisation? [def: %default]"),
+  make_option("--drugs", action = "store_true", help = "Include drug matching section in report."),
+  make_option("--filter", action = "store_true", help = "Filter out low expressed genes."),
+  make_option("--immunogram", action = "store_true", help = "Include immunogram in report."),
+  make_option("--log", action = "store_true", default = TRUE, help = "Log2 transform data before normalisation."),
   make_option("--manta_tsv", type = "character", help = "File path to umccrise 'manta.tsv' output."),
   make_option("--norm", type = "character", help = "Normalisation method."),
-  make_option("--pcgr_splice_vars", action = "store_false", default = TRUE, help = "Include non-coding splice region variants reported in PCGR? [def: %default]"),
+  make_option("--pcgr_splice_vars", action = "store_true", help = "Include non-coding splice region variants reported in PCGR."),
   make_option("--pcgr_tier", default = 4, type = "integer", help = "Tier threshold for reporting variants reported in PCGR. [def: %default]"),
   make_option("--pcgr_tiers_tsv", type = "character", help = "File path to PCGR 'snvs_indels.tiers.tsv' output."),
-  make_option("--project", type = "character", help = "Project name."),
+  make_option("--project", type = "character", help = "Project name, used for annotation purposes only."),
   make_option("--purple_gene_tsv", type = "character", help = "File path to PURPLE 'purple.cnv.gene.tsv' output."),
   make_option("--report_dir", type = "character", help = "Directory path to output report."),
-  make_option("--salmon", type = "character", help = "File path to salmon 'quant.sf' output."),
+  make_option("--salmon", type = "character", help = "File path to salmon 'quant.genes.sf' output."),
   make_option("--sample_name", type = "character", help = "Sample name to be presented in report."),
   make_option("--sample_source", default = "-", type = "character", help = "Type of investigated sample. [def: %default]"),
-  make_option("--save_tables", action = "store_false", default = TRUE, help = "Save interactive summary tables as HTML? [def: %default]"),
+  make_option("--save_tables", action = "store_true", help = "Save interactive summary tables as HTML."),
   make_option("--scaling", default = "gene-wise", type = "character", help = "Scaling for z-score transformation (gene-wise or group-wise). [def: %default]"),
   make_option("--subject_id", type = "character", help = "Subject ID."),
   make_option("--top_genes", default = 5, type = "integer", help = "Number of top ranked genes to be presented in report."),
   make_option("--transform", default = "CPM", type = "character", help = "Transformation method to be used when converting read counts. [def: %default]"),
-  make_option("--umccrise", type = "character", help = "Directory path of the corresponding WGS-related data."),
-  make_option(c("--version", "-v"), action = "store_true", default = FALSE, help = "Print RNAsum version and exit."),
+  make_option("--umccrise", type = "character", help = "Directory path of the corresponding WGS-related umccrise data."),
+  make_option(c("--version", "-v"), action = "store_true", help = "Print RNAsum version and exit."),
   make_option("--html_dir", type = "character", default = getwd(), help = "Directory path to output final HTML report. [def: current directory (%default)]")
 )
 
 parser <- optparse::OptionParser(option_list = option_list, formatter = optparse::TitledHelpFormatter)
 opt <- optparse::parse_args(parser)
 
-if (opt$version) {
+if (!is.null(opt$version)) {
   cat(as.character(packageVersion("RNAsum")), "\n")
   quit("no", status = 0, runLast = FALSE)
 }
@@ -60,9 +60,17 @@ opt$help <- NULL
 html_dir <- opt$html_dir
 opt$html_dir <- NULL
 
+##### Convert missing flags to FALSE
+flags <- c("batch_rm", "dataset_name_incl", "drugs", "filter", "immunogram", "log", "pcgr_splice_vars", "save_tables")
+for (flag in flags) {
+  if (is.null(opt[[flag]])) {
+    opt[[flag]] <- FALSE
+  }
+}
+
 ##### Check required args
 if (is.null(opt$sample_name) || is.null(opt$report_dir)) {
-  cat("'--sample_name' and '--report_dir' are required\n")
+  cat("'--sample_name' and '--report_dir' are required!\n")
   quit("no", status = 1, runLast = FALSE)
 }
 if (!toupper(opt$dataset) %in% names(RNAsum::REFERENCE_DATASETS)) {

--- a/inst/cli/rnasum.R
+++ b/inst/cli/rnasum.R
@@ -13,6 +13,7 @@ suppressMessages(library(glue, include.only = "glue"))
 suppressMessages(library(fs, include.only = "dir_create"))
 
 option_list <- list(
+  make_option("--arriba_dir", type = "character", help = "Directory path to Arriba results containing fusions.pdf and fusions.tsv."),
   make_option("--arriba_pdf", type = "character", help = "File path of Arriba PDF output."),
   make_option("--arriba_tsv", type = "character", help = "File path of Arriba TSV output."),
   make_option("--batch_rm", action = "store_true", help = "Remove batch-associated effects between datasets."),

--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -63,7 +63,7 @@ knitr::opts_chunk$set(timeit = TRUE, echo = FALSE)
 ```
 
 ```{r load_pkgs, message=FALSE}
-source(here::here("inst/rmd/params/pd.R")) # for use with 'Run All Chunks Above'
+# source(here::here("inst/rmd/params/pd.R")) # for use with 'Run All Chunks Above'
 # source(here::here("inst/rmd/params/sk.R")) # for use with 'Run All Chunks Above'
 ensembl_version <- 86L
 ensdb_pkg <- paste0("EnsDb.Hsapiens.v", ensembl_version)
@@ -379,7 +379,7 @@ library_size <- d |>
   ggplot2::ggplot(aes(x = "", y = Library_size)) +
   ggplot2::geom_violin(fill = "transparent", colour = "grey80", alpha = 0.04) +
   ggforce::geom_sina(aes(colour = Target, group = 1), seed = 42, na.rm = TRUE) +
-  ggplot2::geom_hline(yintercept = patient_libsize, colour = "blue", size = 1.2) +
+  ggplot2::geom_hline(yintercept = patient_libsize, colour = "blue", alpha = 0.2, linewidth = 1.2) +
   ggplot2::theme_minimal() +
   ggplot2::scale_y_continuous(breaks = scales::breaks_pretty(8))
 
@@ -4778,7 +4778,6 @@ x |>
   ) |>
   dplyr::bind_rows(tibble::tibble(n = "", name = "TOTAL", value = tot)) |>
   knitr::kable()
-# knitr::knit_exit()
 ```
 
 ### SessionInfo {.tabset .tabset-pills}

--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -10,6 +10,7 @@ output:
   rmdformats::material:
     highlight: kate
 params:
+  arriba_dir: NULL
   arriba_pdf: NULL
   arriba_tsv: NULL
   batch_rm: TRUE

--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -1750,7 +1750,7 @@ NOTE, the `r if (params$filter) { nrow(ref_dataset.list[[dataset]][["combined_da
 
 Violin plot illustrating library size for each sample.
 
-```{r library_size, comment = NA, message=FALSE, warning=FALSE, fig.width = 8, fig.height = 3}
+```{r library_size, comment = NA, message=FALSE, warning=FALSE, fig.width = 5, fig.height = 5}
 library_size
 ```
 
@@ -2938,7 +2938,7 @@ Section overlaying the mRNA expression data with per-gene somatic copy-number (C
 
 ### - Genomic view
 
-`r if (runPurpleChunk) { nrow(ref_dataset.list[[dataset]][["expr_mut_cn_data_all"]])} else { cat("0") }` genes with available CN data (*y-axis*) are presented in the genomic context (*x-axis*). **`r if (runPurpleChunk) { nrow(ref_dataset.list[[dataset]][["expr_mut_cn_data"]]) } else { length(NULL) }`** of them (indicated by *various colours*) are [Cancer genes] and are gained `r if ( runPurpleChunk ) { paste0("(CN values >= ", cn_top, ")") }` or lost `r if ( runPurpleChunk ) { paste0("(CN values <= ", cn_bottom, ")") }`. All other genes are marked in [*gray*]{style="color:#808080"} or *black*.
+`r if (runPurpleChunk) { nrow(ref_dataset.list[[dataset]][["expr_mut_cn_data_all"]])} else { cat("0") }` genes with available CN data (*y-axis*) are presented in the genomic context (*x-axis*). **`r if (runPurpleChunk) { nrow(ref_dataset.list[[dataset]][["expr_mut_cn_data"]]) } else { length(NULL) }`** of them (indicated by [*red*]{style="color:#FF0000"}) are [Cancer genes] and are gained `r if ( runPurpleChunk ) { paste0("(CN values >= ", cn_top, ")") }` or lost `r if ( runPurpleChunk ) { paste0("(CN values <= ", cn_bottom, ")") }`. All other genes are marked in [*gray*]{style="color:#808080"}/*black* (alternating per chromosome).
 
 ```{r cn_genomic_view, comment = NA, message=FALSE, warning=FALSE, fig.width = 8.3, fig.height = 4, eval = runPurpleChunk}
 ##### Update MySQL commend to populate RNA-seq data portal
@@ -3045,10 +3045,11 @@ if (nrow(data.annot) > 0) {
         "\nchr: ", manhattanr.res$data$CHR
       ),
       marker = list(
-        color = "limegreen",
+        color = "red",
         size = 10,
+        opacity = 0.5,
         line = list(
-          color = "grey",
+          color = "black",
           width = 1
         )
       ),

--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -4,7 +4,6 @@ author: 'UMCCR'
 date: '`r date()`'
 output:
   html_document:
-    code_download: true
     theme: readable
     toc: true
     toc_float: true

--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -95,6 +95,9 @@ ensdb_pkg <- paste0("EnsDb.Hsapiens.v", ensembl_version)
 ```{r read_data, message=FALSE, warning=FALSE, comment=NA}
 dataset <- toupper(params$dataset)
 dataset_name_incl <- if_else(params$dataset_name_incl, glue("_{params$dataset}"), "")
+# Define Z-transformation direction
+scaling <- if_else(tolower(params$scaling) == "gene-wise", "gene-wise", "group-wise")
+
 ##### Grab umccrise SBJ for MySQL insert command.
 # TODO (PD): revisit subjectID
 subjectID <- ifelse(!is.null(params$subject_id), params$subject_id, "")
@@ -1179,9 +1182,6 @@ targets <- ref_dataset.list[[dataset]][["sample_annot"]]
 dat1 <- ref_dataset.list[[dataset]][["data_to_report"]]
 
 ##### Percentiles
-# Define Z-transformation direction
-scaling <- if_else(tolower(params$scaling) == "gene-wise", "gene-wise", "group-wise")
-
 genes.expr.perc <- RNAsum::exprTable(
   type = "perc",
   data = dat1,

--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -20,6 +20,7 @@ params:
   dataset_name_incl: FALSE
   dragen_fusions: NULL
   dragen_mapping_metrics: NULL
+  dragen_wts_dir: NULL
   drugs: FALSE
   filter: TRUE
   immunogram: FALSE

--- a/man/read_sample_data.Rd
+++ b/man/read_sample_data.Rd
@@ -20,27 +20,14 @@ A list of the input sample data.
 }
 \description{
 Reads sample data, including Arriba fusions, Arriba plots, Salmon counts,
-and DRAGEN fusions.
+DRAGEN fusions, DRAGEN mapping metrics, Manta SVs, PURPLE CNVs, and PCGR SNVs.
 }
 \examples{
 p <- list(
-  dragen_rnaseq = system.file("rawdata/test_data/dragen", package = "RNAsum"),
-  arriba_pdf = system.file("rawdata/test_data/dragen/arriba/fusions.pdf", package = "RNAsum"),
-  arriba_tsv = system.file("rawdata/test_data/dragen/arriba/fusions.tsv", package = "RNAsum"),
-  dragen_fusions = system.file(
-    "rawdata/test_data/dragen/test_sample_WTS.fusion_candidates.final",
-    package = "RNAsum"
-  ),
-  dragen_mapping_metrics = system.file(
-    "rawdata/test_data/dragen/test.mapping_metrics.csv",
-    package = "RNAsum"
-  ),
+  dragen_wts_dir = system.file("rawdata/test_data/dragen", package = "RNAsum"),
+  arriba_dir = system.file("rawdata/test_data/dragen/arriba", package = "RNAsum"),
   umccrise = system.file(
     "rawdata/test_data/umccrised/test_sample_WGS",
-    package = "RNAsum"
-  ),
-  manta_tsv = system.file(
-    "rawdata/test_data/umccrised/test_sample_WGS/structural/manta.tsv",
     package = "RNAsum"
   )
 )

--- a/tests/testthat/test-roxytest-testexamples-sample_data.R
+++ b/tests/testthat/test-roxytest-testexamples-sample_data.R
@@ -26,7 +26,7 @@ test_that("Function read_sample_data() @ L40", {
     )
   )
   res <- read_sample_data(p, tempdir())
-  expect_equal(length(res), 5)
+  expect_equal(length(res), 6)
   expect_null(res$salmon)
 })
 

--- a/tests/testthat/test-roxytest-testexamples-sample_data.R
+++ b/tests/testthat/test-roxytest-testexamples-sample_data.R
@@ -2,36 +2,23 @@
 
 # File R/sample_data.R: @testexamples
 
-test_that("Function read_sample_data() @ L40", {
+test_that("Function read_sample_data() @ L27", {
   
   p <- list(
-    dragen_rnaseq = system.file("rawdata/test_data/dragen", package = "RNAsum"),
-    arriba_pdf = system.file("rawdata/test_data/dragen/arriba/fusions.pdf", package = "RNAsum"),
-    arriba_tsv = system.file("rawdata/test_data/dragen/arriba/fusions.tsv", package = "RNAsum"),
-    dragen_fusions = system.file(
-      "rawdata/test_data/dragen/test_sample_WTS.fusion_candidates.final",
-      package = "RNAsum"
-    ),
-    dragen_mapping_metrics = system.file(
-      "rawdata/test_data/dragen/test.mapping_metrics.csv",
-      package = "RNAsum"
-    ),
+    dragen_wts_dir = system.file("rawdata/test_data/dragen", package = "RNAsum"),
+    arriba_dir = system.file("rawdata/test_data/dragen/arriba", package = "RNAsum"),
     umccrise = system.file(
       "rawdata/test_data/umccrised/test_sample_WGS",
-      package = "RNAsum"
-    ),
-    manta_tsv = system.file(
-      "rawdata/test_data/umccrised/test_sample_WGS/structural/manta.tsv",
       package = "RNAsum"
     )
   )
   res <- read_sample_data(p, tempdir())
   expect_equal(length(res), 6)
-  expect_null(res$salmon)
+  expect_null(res$salmon) # because tx2gene in NULL
 })
 
 
-test_that("Function read_wgs_data() @ L91", {
+test_that("Function read_wgs_data() @ L103", {
   
   p <- list(
     umccrise = system.file("rawdata/test_data/umccrised/test_sample_WGS", package = "RNAsum"),

--- a/tests/testthat/test-roxytest-testexamples-sample_data.R
+++ b/tests/testthat/test-roxytest-testexamples-sample_data.R
@@ -31,7 +31,7 @@ test_that("Function read_sample_data() @ L40", {
 })
 
 
-test_that("Function read_wgs_data() @ L84", {
+test_that("Function read_wgs_data() @ L91", {
   
   p <- list(
     umccrise = system.file("rawdata/test_data/umccrised/test_sample_WGS", package = "RNAsum"),


### PR DESCRIPTION
Okay, a few more changes below. I'm gonna merge this one to get the docker/conda deployment working, but please let me know if these changes don't make sense @skanwal!

### Devtools

Multiple small changes to satisfy devtools crancheck (e.g. `.data$` and var quoting)

### Fusions

Sort table by `*dna_support`, `reported_fusion`, `fusion_caller`

### CLI

- I've gone ahead and changed the following options to be flags that you need to specify in order to enable:
  - `--batch_rm`
  - `--dataset_name_incl`
  - `--drugs`
  - `--filter`
  - `--immunogram`
  - `--log`
  - `--pcgr_splice_vars`
  - `--save_tables`
This means you need to be explicit for those! If we want to have some of those enabled by default, we should instead create negating options e.g. `--nofilter`, `--nolog` etc.

- Directory inputs: handle Dragen WTS and Arriba directories. I've tested this locally but would need a bit more testing:
  - `dragen_wts_dir`: if this is specified and _any_ of salmon, fusions, or mapmetrics are not specified, do a `list.files` in that directory to match the specific file patterns. If no matches, those params become NULL (e.g. `dragen_fusions` becomes NULL). Note that for the salmon counts we're looking for the `quant.genes.sf` file, not the `quant.sf` one.
  - `arriba_dir`: same. If you specify `arriba_dir` and don't specify `arriba_tsv` or `arriba_pdf`, it constructs the paths to those as `file.path(arriba_dir, "fusions.[tsv/pdf]")`

### Structural variants

- The `sv_prioritize` function in prod has a bug where it reads in the `SR` column that has split read support for ref and alt separated by `,` in a _numeric_ column ignoring the `,`, so that if you have an SR of `20,15`, that gets read in as `2015`. This has downstream ramifications when column splitting happens so the SR alt becomes `NA` for all variants. Same thing happens for PR alt. This happens because there are no `col_classes` specified when using `readr::read_tsv`, so `readr` does its best to infer what on earth the columns are, but here its guess was erroneous.
But. In a fortunate turn of events, the only impact this has on the SV table is that the SR/PR columns are blank, and the BND/SR filter applied at https://github.com/umccr/RNAsum/blob/master/rmd_files/RNAseq_report.Rmd#L1638 does not filter out anything since SR is NA for all rows there. And I'm actually okay with that, since that filter has been changed in umccrise itself. So all good!

- I've gone ahead and modified that function in dev to read in columns with explicit classes, and I've completely removed that filter. So numbers stack up now. I've also handled the `tidyr::unnest(annotation)` warning we've been getting since forever.

### Conda

- I've pinned dependencies to match the current ones in prod, main ones are:
  - `base`: 4.1.3
  - `edgeR`: 3.36.0
  - `limma`: 3.50.1
- `manhattanly` didn't have a conda pkg for R v4.1 so I created one at https://anaconda.org/umccr/r-manhattanly using the recipe at https://github.com/umccr/conda_recipes/tree/main/r-manhattanly
- I also released a `RNAsum.data` v0.0.3 for R v4.1 (same as v0.0.2, but that was build for R v4.2). Todo would be to have that built for R v4.1/4.2/4.3 in parallel. It's okay for now.

### Rmd other

- Added `arriba_dir` and `dragen_wts_dir` params.
- The `scaling` param needed to be evaluated earlier.
- The hline in the violin plot was made more transparent and changed deprecated `size` to `linewidth`. Also increased its height and decreased its width. Looks less wonky now.
- CN genomic view plot has cancer genes in red points with 0.5 opacity (so that you can see through them)

### inst/scripts/icav1_download_and_run.R

- I use this to automatically download results from GDS and run the report locally, and it works well (when there are no rounding bugs locally!)