### PR TITLE
Explicitly rename Diff_Perc and Diff_Z_score columns

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,5 @@
 ^pkgdown$
 ^data-raw$
 ^\.bumpversion\.cfg$
+
+inst/rmd/rnasum.html

--- a/R/pcgr.R
+++ b/R/pcgr.R
@@ -156,7 +156,7 @@ cn_subset <- function(gene.mut = NULL, cn_data, expr_data.z, expr_data.perc) {
   d <- cn_data.sub |>
     dplyr::left_join(expr_data.perc.sub, by = c("gene" = "SYMBOL")) |>
     dplyr::left_join(expr_data.z.sub, by = c("gene" = "SYMBOL"), suffix = c("_Perc", "_Z_score")) |>
-    dplyr::rename("CN" = "MeanCopyNumber", "Gene" = "gene")
+    dplyr::rename("CN" = "MeanCopyNumber", "Gene" = "gene", "Diff_Perc" = 3, "Diff_Z_score" = 4)
   if (!is.null(gene.mut)) {
     d <- d |>
       dplyr::left_join(gene.mut.sub, by = c("Gene" = "gene")) |>


### PR DESCRIPTION
Fixes #129. Slightly tough to crack. This got through the tests since I've been using non-PAAD refdata, whereas when you use PAAD, you get a couple columns renamed to distinguish between PAAD (TCGA) and PAAD (UMCCR).