### PR TITLE
Move rm expression before circos table view

### DIFF
--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -2399,9 +2399,8 @@ if (nrow(fusion_annot_top) > 0) {
         c(FALSE, TRUE), c("transparent", "lightgreen")
       )
     )
-
-  fusions.genomicView
   rm(fusion_annot_top.clean)
+  fusions.genomicView
 }
 ```
 


### PR DESCRIPTION
Fixes #132. This actually took me a ridiculous amount of time to figure out. And I'm not even sure why the DT doesn't render with the `rm` afterwards. Anyway, works now!