### PR TITLE
Do not run SV chunks when 0 expressed SV genes

### DIFF
--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -1421,7 +1421,13 @@ fusions_ann <- RNAsum::fusions_annot(
 ```{r fusions_and_manta_data_prep, comment = NA, message=FALSE, warning=FALSE, eval = runSVsChunk}
 manta_sv <- sample_data.list[["wgs"]][["manta_tsv"]] |>
   RNAsum::manta_process()
-
+tmp_sv_genes <- manta_sv$genes_all$Genes
+tmp_expressed_sv_genes <- tmp_sv_genes[tmp_sv_genes %in% ref_dataset.list[[dataset]][["gene_annot_all"]]$SYMBOL]
+if (length(tmp_expressed_sv_genes) == 0) {
+  # from now on don't evaluate SV chunks
+  runSVsChunk <- FALSE
+}
+rm(tmp_sv_genes, tmp_expressed_sv_genes)
 ##### Compare fusion genes called by MANTA
 ##### First limit MANTA output to fusions only
 if (runFusionChunk) {


### PR DESCRIPTION
Currently the SV chunks don't run only when the SV file is empty. When the genes in there are not expressed, it causes issues with the exprTable which tries to take in a NULL `genes` object. Handling that here.

Fixes #172. Tested locally on the sample hitting the bug.