### PR TITLE
Handling new PURPLE CNV file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,7 +16,6 @@
 ^data-raw$
 ^\.bumpversion\.toml$
 
-inst/rmd/rnasum.html
 ^CODE_OF_CONDUCT\.md$
 ^inst/rmd/rnasum.html$
 inst/rmd/html

--- a/R/sample_data.R
+++ b/R/sample_data.R
@@ -337,20 +337,32 @@ immune_summary <- function(tbl_imarkers, tbl_igram = NULL, igram_param = TRUE) {
 #'
 #' @export
 ppl_cnv_som_gene_read <- function(x) {
-  nm <- c(
-    "chromosome" = "c", "start" = "i", "end" = "i", "gene" = "c",
+  ct <- list(
+    "chromosome" = "c", "start" = "d", "end" = "d", "gene" = "c",
     "minCopyNumber" = "d", "maxCopyNumber" = "d",
     "unused" = "c", "somaticRegions" = "d", "germlineHomDeletionRegions" = "d",
     "germlineHetToHomDeletionRegions" = "d",
     "transcriptId" = "c", "transcriptVersion" = "c", "chromosomeBand" = "c",
-    "minRegions" = "d", "minRegionStart" = "i", "minRegionEnd" = "i",
+    "minRegions" = "d", "minRegionStart" = "d", "minRegionEnd" = "d",
     "minRegionStartSupport" = "c", "minRegionEndSupport" = "c",
     "minRegionMethod" = "c", "minMinorAlleleCopyNumber" = "d"
   )
+  # PURPLE as of at least v3.9.2 (2023-09-05) has some different columns
+  ct2 <- list(
+    "chromosome" = "c", "start" = "d", "end" = "d", "gene" = "c",
+    "minCopyNumber" = "d", "maxCopyNumber" = "d",
+    "somaticRegions" = "d", "transcriptId" = "c", "isCanonical" = "c",
+    "chromosomeBand" = "c",
+    "minRegions" = "d", "minRegionStart" = "d", "minRegionEnd" = "d",
+    "minRegionStartSupport" = "c", "minRegionEndSupport" = "c",
+    "minRegionMethod" = "c", "minMinorAlleleCopyNumber" = "d",
+    "depthWindowCount" = "d"
+  )
 
-  ctypes <- paste(nm, collapse = "")
-  purple_cnv_gene <- readr::read_tsv(x, col_types = ctypes)
-  assertthat::assert_that(ncol(purple_cnv_gene) == length(nm))
-  assertthat::assert_that(all(colnames(purple_cnv_gene) == names(nm)))
-  purple_cnv_gene
+  hdr <- readr::read_tsv(x, n_max = 0, show_col_types = FALSE)
+  if (all(names(ct2) %in% colnames(hdr))) {
+    ct <- ct2
+  }
+  d <- readr::read_tsv(x, col_types = ct)
+  d[]
 }

--- a/R/utils_shortcuts.R
+++ b/R/utils_shortcuts.R
@@ -23,4 +23,6 @@ dummy1 <- function() {
   optparse::make_option
   preprocessCore::normalize.quantiles
   ragg::agg_png
+  purrr::map
+  stringr::str_detect
 }

--- a/man/pcgr_tiers_tsv_read.Rd
+++ b/man/pcgr_tiers_tsv_read.Rd
@@ -2,18 +2,19 @@
 % Please edit documentation in R/pcgr.R
 \name{pcgr_tiers_tsv_read}
 \alias{pcgr_tiers_tsv_read}
-\title{Read PCGR Tiers TSV File}
+\title{Read PCGR TSV File}
 \usage{
 pcgr_tiers_tsv_read(x = NULL)
 }
 \arguments{
-\item{x}{Path to PCGR \code{snvs_indels.tiers.tsv} file.}
+\item{x}{Path to PCGR \code{snvs_indels.tiers.tsv}/\code{snv_indel_ann.tsv.gz} file.}
 }
 \value{
 A tibble with the contents of the input TSV file, or NULL if x is NULL.
 }
 \description{
-Reads the \code{snvs_indels.tiers.tsv} file output by PCGR.
+Reads the \code{snvs_indels.tiers.tsv} (or v2's \code{snv_indel_ann.tsv.gz}) file output
+by PCGR.
 }
 \examples{
 x <- system.file(

--- a/tests/testthat/test-roxytest-testexamples-pcgr.R
+++ b/tests/testthat/test-roxytest-testexamples-pcgr.R
@@ -2,7 +2,7 @@
 
 # File R/pcgr.R: @testexamples
 
-test_that("Function pcgr_tiers_tsv_read() @ L17", {
+test_that("Function pcgr_tiers_tsv_read() @ L18", {
   
   x <- system.file(
     "rawdata/test_data/umccrised/test_sample_WGS/small_variants",


### PR DESCRIPTION
Fixes #174. The columns required for the report (`gene`/`minCopyNumber`/`maxCopyNumber`) are available in the new version.