### PR TITLE
Fix: Initialize runPurple variables to prevent error when input is missing

### DIFF
--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -171,6 +171,10 @@ runPcgrChunk <- !is.null(sample_data.list[["wgs"]][["pcgr_tiers_tsv"]])
 runPurpleChunk <- !is.null(sample_data.list[["wgs"]][["purple_gene_tsv"]])
 runSVsChunk <- (!is.null(sample_data.list[["wgs"]][["sv_tsv"]]) &&
   nrow(sample_data.list[["wgs"]][["sv_tsv"]][["melted"]] > 0))
+
+# [FIX] Initialize these variables to avoid "object not found" error when runPurpleChunk is FALSE
+runPurpleGainsChunk <- FALSE
+runPurpleLossesChunk <- FALSE
 ```
 
 ```{r dragen_mapping_metrics, eval=runDragenMappingMetricsChunk}


### PR DESCRIPTION
### Description
This PR fixes a bug where the pipeline would crash when running with WTS data only (i.e., when no PURPLE/WGS input is provided).

### The Issue
Previously, if `params$purple_gene_tsv` was NULL, the `runPurpleChunk` would be FALSE. Consequently, the logic to define `runPurpleGainsChunk` and `runPurpleLossesChunk` was skipped.
Later in the Rmd file, the code attempted to evaluate chunks based on these variables, resulting in the error:
`Error: ! object 'runPurpleGainsChunk' not found`

### The Fix
I have initialized `runPurpleGainsChunk` and `runPurpleLossesChunk` to `FALSE` in the `chunk_eval` block. This ensures these variables always exist, preventing the crash when PURPLE inputs are missing.

### Verification
Tested locally with the test dataset (`/inst/rawdata/test_data/`) without purple inputs. The report generated successfully without errors.