### PR TITLE
Simplify report title

### DIFF
--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -1,7 +1,5 @@
 ---
-title: 'Patient Transcriptome Summary'
-author: 'UMCCR'
-date: '`r date()`'
+title: 'Patient molecular profiling'
 output:
   html_document:
     theme: readable
@@ -1781,7 +1779,7 @@ summary_table.df <- data.frame(
 rm(summary_table.list)
 ```
 
-Transcriptome summary for patient sample **`r sample_report_title`**.
+**`r sample_report_title`**
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
- change the report title from "Patient Transcriptome Summary" to "Patient molecular profiling"
- remove "UMCCR" from  the report
- remove date from  the report