### PR TITLE
Docker installation update

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -33,6 +33,10 @@ docker run --rm ghcr.io/umccr/rnasum:${VERSION} rnasum.R --version
 docker run --rm ghcr.io/umccr/rnasum:${VERSION} rnasum.R --help
 ```
 
+> **Apple Silicon (arm64) note**: the current released image is built for `linux/amd64` only.
+> On Apple Silicon Macs, Docker Desktop runs it via Rosetta emulation — add `--platform linux/amd64`
+> to each `docker` command. A native arm64 image is planned for a future release.
+
 Mount local data directories with `-v`:
 
 ```bash


### PR DESCRIPTION
Hey @pdiakumis 

I've opened the `docker-update` branch to improve the Docker installation documentation in the README. A few things worth being aware of:

1. **Apple Silicon platform note** — I tested the released `2.0.3` Docker image on an M-series Mac. The image is `linux/amd64`-only, so users need `--platform linux/amd64` for Docker Desktop to run it via Rosetta. I've added a note for this.

2. **Pre-existing render bug in 2.0.3** — During testing I found that the released `2.0.3` image fails to render the full report due to a `plot_legend1` scoping issue in `data_transformation_plot`. This is already fixed in the current dev code, so the next tagged release should be fine. Worth keeping in mind for the `2.0.4` release.

Would you be able to check these in your spare time?