### PR TITLE
Fix --filter, --batch_rm, --log flags to accept explicit values and p…

### DIFF
--- a/inst/cli/rnasum.R
+++ b/inst/cli/rnasum.R
@@ -16,7 +16,7 @@ option_list <- list(
   make_option("--arriba_dir", type = "character", help = "Directory path to Arriba results containing fusions.pdf and fusions.tsv."),
   make_option("--arriba_pdf", type = "character", help = "File path of Arriba PDF output."),
   make_option("--arriba_tsv", type = "character", help = "File path of Arriba TSV output."),
-  make_option("--batch_rm", action = "store_true", help = "Remove batch-associated effects between datasets. [def: TRUE]"),
+  make_option("--batch_rm", type = "logical", default = TRUE, help = "Remove batch-associated effects between datasets. [def: %default]"),
   make_option("--cn_gain", default = 95, type = "integer", help = "CN threshold value to classify genes within gained regions. [def: %default]"),
   make_option("--cn_loss", default = 5, type = "integer", help = "CN threshold value to classify genes within lost regions. [def: %default]"),
   make_option("--dataset", default = "PANCAN", type = "character", help = "Dataset to be used as external reference cohort. [def: %default]"),
@@ -25,9 +25,9 @@ option_list <- list(
   make_option("--dragen_mapping_metrics", type = "character", help = "File path to DRAGEN RNA-seq 'mapping_metrics.csv' output."),
   make_option("--dragen_wts_dir", type = "character", help = "Directory path to DRAGEN RNA-seq results."),
   make_option("--drugs", action = "store_true", help = "Include drug matching section in report."),
-  make_option("--filter", action = "store_true", help = "Filter out low expressed genes. [def: TRUE]"),
+  make_option("--filter", type = "logical", default = TRUE, help = "Filter out low expressed genes. [def: %default]"),
   make_option("--immunogram", action = "store_true", help = "Include immunogram in report."),
-  make_option("--log", action = "store_true", help = "Log2 transform data before normalisation. [def: TRUE]"),
+  make_option("--log", type = "logical", default = TRUE, help = "Log2 transform data before normalisation. [def: %default]"),
   make_option("--norm", type = "character", help = "Normalisation method."),
   make_option("--pcgr_splice_vars", action = "store_true", help = "Include non-coding splice region variants reported in PCGR."),
   make_option("--pcgr_tier", default = 4, type = "integer", help = "Tier threshold for reporting variants reported in PCGR. [def: %default]"),
@@ -60,18 +60,13 @@ if (!is.null(opt$version)) {
 opt$version <- NULL
 opt$help <- NULL
 
-##### Convert missing flags to FALSE (except batch_rm, filter, log which default to TRUE)
+##### Convert missing store_true flags to FALSE
 flags <- c("dataset_name_incl", "drugs", "immunogram", "pcgr_splice_vars", "save_tables")
 for (flag in flags) {
   if (is.null(opt[[flag]])) {
     opt[[flag]] <- FALSE
   }
 }
-
-# Set enhanced normalization defaults (User Method approach)
-opt$batch_rm <- if (is.null(opt$batch_rm)) TRUE else opt$batch_rm
-opt$filter <- if (is.null(opt$filter)) TRUE else opt$filter
-opt$log <- if (is.null(opt$log)) TRUE else opt$log
 
 ##### Check required args
 if (is.null(opt$sample_name) || is.null(opt$report_dir)) {

--- a/inst/rmd/rnasum.Rmd
+++ b/inst/rmd/rnasum.Rmd
@@ -623,6 +623,8 @@ for (i in 2:ncol_transformed) {
   den.y <- sort(c(den.y, den$y))
 }
 
+plot_legend1 <- c(ext_cancer_group, add_cancer_group, int_cancer_group, "Patient")
+
 ##### Plot read counts against transformed data
 if (params$filter) {
   data.df <- tibble(
@@ -656,9 +658,7 @@ if (params$filter) {
 
   ##### Save interactive plot as html file
   RNAsum::saveWidgetFix(counts_vs_transformed, file = file.path(PlotsDir, "counts_vs_transformed.html"))
-  
-  plot_legend1 <- c(ext_cancer_group, add_cancer_group, int_cancer_group, "Patient")
-  
+
   ##### Before filtering
   par(mfrow = c(1, 2))
 


### PR DESCRIPTION
Two related fixes to make --filter FALSE (and --batch_rm/--log FALSE) actually work from the CLI:

1. inst/cli/rnasum.R: changed --filter, --batch_rm, and --log from store_true to type="logical" with default=TRUE. Previously these flags were boolean switches with no way to pass FALSE explicitly; any attempt (e.g. --filter FALSE) caused an immediate parse error. Removed the now-redundant post-parse NULL-coercion block.

Changed all three to type = "logical" with default = TRUE, which lets users override them from the command line:

  rnasum.R --filter FALSE    # disable low-expression filtering
  rnasum.R --batch_rm FALSE  # disable batch correction
  rnasum.R --log FALSE       # disable log2 transformation

Removed the now-redundant post-parse NULL-coercion block.

2. inst/rmd/rnasum.Rmd: moved plot_legend1 assignment out of the if (params$filter) block. The variable was defined only when filter=TRUE but referenced unconditionally in the subsequent data_normalisation_plot chunk, causing a crash whenever filter=FALSE.

Tested: both --filter TRUE (default) and --filter FALSE now render all 219 chunks to a complete HTML report.